### PR TITLE
Extend breakpoint address to 64bit

### DIFF
--- a/src/debug/gdb.c
+++ b/src/debug/gdb.c
@@ -772,7 +772,8 @@ static void gdb_breakpoint(char *req, bool insert)
 	}
 	
 	ptr64_t virt;
-	virt.ptr = address;
+	// Extend the address as the GDB sends the address in 32bits.
+	virt.ptr = UINT64_C(0xffffffff00000000) | address;
 	cpu_t* cpu = dcpu_find_no(cpuno_global);
 	
 	if (code_breakpoint) {

--- a/src/device/dcpu.c
+++ b/src/device/dcpu.c
@@ -266,7 +266,9 @@ static bool dcpu_break(token_t *parm, device_t *dev)
 	}
 	
 	ptr64_t addr;
-	addr.ptr = _addr;
+	// Extend the address as the user will not enter it in 64bit mode
+	// when the emulated CPU is 32bit.
+	addr.ptr = UINT64_C(0xffffffff00000000) | _addr;
 	
 	breakpoint_t *bp = breakpoint_init(addr,
 	    BREAKPOINT_KIND_SIMULATOR);


### PR DESCRIPTION
When the user works with 32bit CPU, we should expect that he will use 32bit addresses even though internally we work with 64bits.
