### PR TITLE
Fixed wrong link in mini-kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Wrong toolchain link in mini-kernel tutorial
+
 ### Added
 
 * Added Mini-kernel multiplatform tutorial (see #70, @HanyzPAPU)

--- a/doc/tutorial/mini-kernel.rst
+++ b/doc/tutorial/mini-kernel.rst
@@ -17,7 +17,7 @@ Toolchain setup
 We expect that you have a cross-compiler toolchain already installed so
 that you can try the examples yourself.
 
-Please, refer to our `instructions <toolchain>`__ if you need help with
+Please, refer to our :doc:`instructions <toolchain>` if you need help with
 installing a toolchain.
 
 Once you have your toolchain ready, we can dive into kernel code for real :-).


### PR DESCRIPTION
Changed an external link to a `:doc:` reference.