### PR TITLE
CI: build on MacOS too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -32,3 +32,24 @@ jobs:
 
     - name: Run tests
       run: make test
+
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        brew install makedepend
+
+    - name: configure
+      run: ./configure
+
+    - name: make
+      run: make
+
+    - name: Show version
+      run: ./msim --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added Mini-kernel multiplatform tutorial (see #70, @HanyzPAPU)
 * RISC-V virtual memory commands tutorial (see #70, @HanyzPAPU)
+* CI builds on MacOS (see #76, #77, @vhotspur)
 
 ### Changed
 


### PR DESCRIPTION
Only builds, tests are not executed because we would need to have PCUT for MacOS (I will try to add that too eventually).

See #76.

