### PR TITLE
RISC-V Generic IMA implementation

### DIFF
--- a/src/device/cpu/riscv_rv_ima/csr.c
+++ b/src/device/cpu/riscv_rv_ima/csr.c
@@ -1,0 +1,1904 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V CSR
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "../../../utils.h"
+#include "csr.h"
+#include "exception.h"
+#include "types.h"
+
+typedef rv_exc_t (*csr_read_func_t)(rv_cpu_t *, csr_num_t csr, uxlen_t *);
+typedef rv_exc_t (*csr_write_func_t)(rv_cpu_t *, csr_num_t csr, uxlen_t);
+typedef rv_exc_t (*csr_set_func_t)(rv_cpu_t *, csr_num_t csr, uxlen_t);
+typedef rv_exc_t (*csr_clear_func_t)(rv_cpu_t *, csr_num_t csr, uxlen_t);
+
+/**
+ * Initialize CSRs
+ *
+ * Expects the csr parameter to be zero-initialized
+ */
+static void rv_init_csr(rv_csr_t *csr, unsigned int procno)
+{
+    csr->misa = RV_ISA;
+    csr->mvendorid = RV_VENDOR_ID;
+    csr->marchid = RV_ARCH_ID;
+    csr->mimpid = RV_IMPLEMENTATION_ID;
+    csr->mhartid = procno;
+
+    csr->mtime = current_timestamp();
+    csr->last_tick_time = csr->mtime;
+
+    csr->asid_len = rv_asid_len;
+}
+
+/**
+ * @brief The minimal privilege from which the given csr can be accessed
+ */
+static rv_priv_mode_t rv_csr_min_priv_mode(csr_num_t csr)
+{
+    return (rv_priv_mode_t) (((unsigned int) csr >> 8) & 0b11);
+}
+
+/**
+ * Structure holding the basic CSR operations
+ */
+typedef struct {
+    csr_read_func_t read; /** Reads the whole CSR */
+    csr_write_func_t write; /** Writes the whole CSR */
+    csr_set_func_t set; /** Sets the bits on position that has a bit set in the given value (writing only to those bits)*/
+    csr_clear_func_t clear; /** Clears the bits on position that has a bit set in the given value (writing only to those bits)*/
+} csr_ops_t;
+
+#define minimal_privilege(priv, cpu) \
+    { \
+        if (cpu->priv_mode < priv) \
+            return rv_exc_illegal_instruction; \
+    }
+#define default_csr_functions(csr_name, priv) \
+    static rv_exc_t csr_name##_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target) \
+    { \
+        minimal_privilege(priv, cpu); \
+        *target = cpu->csr.csr_name; \
+        return rv_exc_none; \
+    } \
+    static rv_exc_t csr_name##_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value) \
+    { \
+        minimal_privilege(priv, cpu); \
+        cpu->csr.csr_name = value; \
+        return rv_exc_none; \
+    } \
+    static rv_exc_t csr_name##_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value) \
+    { \
+        minimal_privilege(priv, cpu); \
+        cpu->csr.csr_name |= value; \
+        return rv_exc_none; \
+    } \
+    static rv_exc_t csr_name##_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value) \
+    { \
+        minimal_privilege(priv, cpu); \
+        cpu->csr.csr_name &= ~value; \
+        return rv_exc_none; \
+    }
+
+static rv_exc_t invalid_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+static rv_exc_t invalid_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+#define is_counter_enabled_m(cpu, counter) (cpu->csr.mcounteren & (1 << counter))
+#define is_counter_enabled_s(cpu, counter) (cpu->csr.scounteren & (1 << counter))
+#define is_high_counter(csr) (csr & 0x080)
+
+static inline void read_counter_csr_unchecked(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    int counter = csr & 0x1F;
+
+    int offset = is_high_counter(csr) ? 32 : 0;
+
+    switch (counter) {
+    case (csr_cycle & 0x1F): {
+        *target = EXTRACT_BITS(cpu->csr.cycle, offset, offset + 32);
+        break;
+    }
+    case (csr_time & 0x1F): {
+        *target = EXTRACT_BITS(cpu->csr.mtime, offset, offset + 32);
+        break;
+    }
+    case (csr_instret & 0x1F): {
+        *target = EXTRACT_BITS(cpu->csr.instret, offset, offset + 32);
+        break;
+    }
+    default: {
+        uint64_t hpc = cpu->csr.hpmcounters[counter - 3];
+        *target = EXTRACT_BITS(hpc, offset, offset + 32);
+        break;
+    }
+    }
+}
+
+static rv_exc_t counter_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+
+    // lowest 5 bits
+    int counter = csr * 0x1F;
+
+    if (rv_csr_min_priv_mode(csr) != rv_mmode) {
+
+        if (cpu->priv_mode == rv_smode && !is_counter_enabled_m(cpu, counter)) {
+            return rv_exc_illegal_instruction;
+        }
+
+        if (cpu->priv_mode == rv_umode && !(is_counter_enabled_m(cpu, counter) && is_counter_enabled_s(cpu, counter))) {
+            return rv_exc_illegal_instruction;
+        }
+
+    } else if (cpu->priv_mode != rv_mmode) {
+        return rv_exc_illegal_instruction;
+    } else if (counter == (csr_time & 0x1F)) {
+        // mtime is not a csr
+        return rv_exc_illegal_instruction;
+    }
+
+    read_counter_csr_unchecked(cpu, csr, target);
+
+    return rv_exc_none;
+}
+
+static rv_exc_t counter_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+
+    // only mmode can write to counters
+    minimal_privilege(rv_mmode, cpu);
+
+    // global counters are r/o
+    if (rv_csr_min_priv_mode(csr) != rv_mmode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    int counter = csr & 0x1F;
+
+    // mtime is not a csr
+    if (counter == (csr_time & 0x1F)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    uint64_t val = 0;
+    uint64_t mask = 0;
+
+    if (is_high_counter(csr)) {
+        val = ((uint64_t) value) << 32;
+        mask = 0x00000000FFFFFFFF;
+    } else {
+        val = value;
+        mask = 0xFFFFFFFF00000000;
+    }
+
+    switch (csr) {
+    case (csr_mcycle): {
+        cpu->csr.cycle = (cpu->csr.cycle & mask) | val;
+        cpu->csr.external_STIP = ((uxlen_t) cpu->csr.cycle) >= cpu->csr.scyclecmp;
+        break;
+    }
+    case (csr_minstret): {
+        cpu->csr.instret = (cpu->csr.instret & mask) | val;
+        break;
+    }
+    default: {
+        uint64_t hpc = cpu->csr.hpmcounters[counter - 3];
+        cpu->csr.hpmcounters[counter - 3] = (hpc & mask) | val;
+        break;
+    }
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t counter_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+
+    // only mmode can write to counters
+    minimal_privilege(rv_mmode, cpu);
+
+    // global counters are r/o
+    if (rv_csr_min_priv_mode(csr) != rv_mmode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    int counter = csr & 0x1F;
+
+    // mtime is not a csr
+    if (counter == (csr_time & 0x1F)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    uint64_t val = is_high_counter(csr) ? ((uint64_t) value) << 32 : value;
+
+    switch (csr) {
+    case (csr_mcycle): {
+        cpu->csr.cycle |= val;
+        cpu->csr.external_STIP = ((uxlen_t) cpu->csr.cycle) >= cpu->csr.scyclecmp;
+        break;
+    }
+    case (csr_minstret): {
+        cpu->csr.instret |= val;
+        break;
+    }
+    default: {
+        cpu->csr.hpmcounters[counter - 3] |= val;
+        break;
+    }
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t counter_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    // only mmode can write to counters
+    minimal_privilege(rv_mmode, cpu);
+
+    // global counters are r/o
+    if (rv_csr_min_priv_mode(csr) != rv_mmode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    int counter = csr & 0x1F;
+
+    // mtime is not a csr
+    if (counter == (csr_time & 0x1F)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    uint64_t val = is_high_counter(csr) ? ((uint64_t) value) << 32 : value;
+
+    switch (csr) {
+    case (csr_mcycle): {
+        cpu->csr.cycle &= ~val;
+        cpu->csr.external_STIP = (cpu->csr.cycle) >= cpu->csr.scyclecmp;
+        break;
+    }
+    case (csr_minstret): {
+        cpu->csr.instret &= ~val;
+        break;
+    }
+    default: {
+        cpu->csr.hpmcounters[counter - 3] &= ~val;
+        break;
+    }
+    }
+
+    return rv_exc_none;
+}
+
+#define mcountinhibit_mask (~UINT32_C(0b10))
+
+static rv_exc_t mcountinhibit_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mcountinhibit;
+    return rv_exc_none;
+}
+
+static rv_exc_t mcountinhibit_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mcountinhibit = value & mcountinhibit_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mcountinhibit_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mcountinhibit |= value & mcountinhibit_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mcountinhibit_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mcountinhibit &= ~(value & mcountinhibit_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t mhpmevent_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    int event = (csr & 0x1F) - 3;
+    *target = cpu->csr.hpmevents[event];
+    return rv_exc_none;
+}
+
+static rv_exc_t mhpmevent_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    int event = (csr & 0x1F) - 3;
+
+    if (value < hpm_event_count) {
+        cpu->csr.hpmevents[event] = value;
+    }
+    return rv_exc_none;
+}
+
+static rv_exc_t mhpmevent_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    int event = (csr & 0x1F) - 3;
+
+    int val = cpu->csr.hpmevents[event] | value;
+
+    if (val < hpm_event_count) {
+        cpu->csr.hpmevents[event] = val;
+    }
+    return rv_exc_none;
+}
+
+static rv_exc_t mhpmevent_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    int event = (csr & 0x1F) - 3;
+
+    int val = cpu->csr.hpmevents[event] & ~value;
+
+    if (val < hpm_event_count) {
+        cpu->csr.hpmevents[event] = val;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t pmpcfg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpcfg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpcfg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpcfg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpaddr_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpaddr_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpaddr_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t pmpaddr_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t sstatus_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.mstatus & rv_csr_sstatus_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sstatus_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    // Masked write of low 32 bits
+    // TODO: Reconsider this masking
+    cpu->csr.mstatus = (cpu->csr.mstatus & 0xFFFFFFFF00000000) | (value & rv_csr_sstatus_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t sstatus_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    // Masked write
+    cpu->csr.mstatus |= (value & rv_csr_sstatus_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t sstatus_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    // Masked write
+    cpu->csr.mstatus &= ~(value & rv_csr_sstatus_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t sie_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.mie & rv_csr_si_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sie_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    // write only to si bits, preserve rest
+    cpu->csr.mie &= ~rv_csr_si_mask;
+    cpu->csr.mie |= value & rv_csr_si_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sie_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.mie |= value & rv_csr_si_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sie_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.mie &= ~(value & rv_csr_si_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t sip_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    // The SEIP bit is the logical OR of the value in MIP and the status from external interrupt controller
+    // Full explanation RISC-V Privileged spec section 3.1.9 Machine Interrupt Registers (mip and mie)
+    *target = (cpu->csr.mip & rv_csr_si_mask)
+            | (cpu->csr.external_SEIP ? rv_csr_sei_mask : 0)
+            | (cpu->csr.external_STIP ? rv_csr_sti_mask : 0);
+    return rv_exc_none;
+}
+
+static rv_exc_t sip_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    // only ssip is writable
+    cpu->csr.mip &= ~rv_csr_ssi_mask;
+    cpu->csr.mip |= value & rv_csr_ssi_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sip_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.mip |= value & rv_csr_ssi_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sip_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.mip &= ~(value & rv_csr_ssi_mask);
+    return rv_exc_none;
+}
+
+#define scvec_mask 0xFFFFFFFD
+
+static rv_exc_t stvec_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.stvec;
+    return rv_exc_none;
+}
+
+static rv_exc_t stvec_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.stvec = value & scvec_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t stvec_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.stvec |= value & scvec_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t stvec_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.stvec &= ~(value & scvec_mask);
+    return rv_exc_none;
+}
+
+default_csr_functions(scounteren, rv_smode)
+
+#define senvcfg_mask 0x71
+
+        static rv_exc_t senvcfg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.senvcfg;
+    return rv_exc_none;
+}
+
+static rv_exc_t senvcfg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.senvcfg = value & senvcfg_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t senvcfg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.senvcfg |= value & senvcfg_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t senvcfg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.senvcfg &= ~(value & senvcfg_mask);
+    return rv_exc_none;
+}
+
+default_csr_functions(sscratch, rv_smode)
+
+#if XLEN == 32
+#define sepc_mask 0xFFFFFFFC
+#else
+#define sepc_mask 0xFFFFFFFFFFFFFFFC
+#endif
+
+        static rv_exc_t sepc_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.sepc;
+    return rv_exc_none;
+}
+
+static rv_exc_t sepc_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.sepc = value & sepc_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sepc_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.sepc |= value & sepc_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t sepc_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.sepc &= ~(value & sepc_mask);
+    return rv_exc_none;
+}
+
+static bool is_exception_code(uxlen_t num)
+{
+    if (RV_INTERRUPT_EXC_BITS & num) {
+        return RV_EXCEPTION_MASK(num) & RV_INTERRUPTS_MASK;
+    }
+    return RV_EXCEPTION_MASK(num) & RV_EXCEPTIONS_MASK;
+}
+
+static rv_exc_t scause_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.scause;
+    return rv_exc_none;
+}
+
+static rv_exc_t scause_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    if (is_exception_code(value)) {
+        cpu->csr.scause = value;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t scause_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    uxlen_t val = value | cpu->csr.scause;
+    if (is_exception_code(val)) {
+        cpu->csr.scause = val;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t scause_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+
+    uxlen_t val = ~value & cpu->csr.scause;
+    if (is_exception_code(val)) {
+        cpu->csr.scause = val;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+
+    return rv_exc_none;
+}
+
+default_csr_functions(stval, rv_smode)
+
+        static rv_exc_t satp_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    if (rv_csr_mstatus_tvm(cpu)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    *target = cpu->csr.satp;
+    return rv_exc_none;
+}
+
+static rv_exc_t satp_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    if (rv_csr_mstatus_tvm(cpu)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    // Construct a mask that will zero-out non-active asid bits
+    uxlen_t active_asid_mask = ((1UL << cpu->csr.asid_len) - 1) << rv_csr_satp_asid_offset;
+
+    // Create a full mask for the SATP CSR
+    uxlen_t mask = rv_csr_satp_mode_mask | active_asid_mask | rv_csr_satp_ppn_mask;
+
+    cpu->csr.satp = value & mask;
+
+    if (rv_csr_satp_is_bare(cpu)) {
+        cpu->csr.satp = 0;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t satp_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    if (rv_csr_mstatus_tvm(cpu)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    // Construct a mask that will zero-out non-active asid bits
+    uxlen_t active_asid_mask = ((1UL << cpu->csr.asid_len) - 1) << rv_csr_satp_asid_offset;
+
+    // Create a full mask for the SATP CSR
+    uxlen_t mask = rv_csr_satp_mode_mask | active_asid_mask | rv_csr_satp_ppn_mask;
+
+    cpu->csr.satp |= value & mask;
+
+    if (rv_csr_satp_is_bare(cpu)) {
+        cpu->csr.satp = 0;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t satp_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    if (rv_csr_mstatus_tvm(cpu)) {
+        return rv_exc_illegal_instruction;
+    }
+
+    // Construct a mask that will zero-out non-active asid bits
+    uxlen_t active_asid_mask = ((1UL << cpu->csr.asid_len) - 1) << rv_csr_satp_asid_offset;
+
+    // Create a full mask for the SATP CSR
+    uxlen_t mask = rv_csr_satp_mode_mask | active_asid_mask | rv_csr_satp_ppn_mask;
+
+    cpu->csr.satp &= ~(value & mask);
+
+    if (rv_csr_satp_is_bare(cpu)) {
+        cpu->csr.satp = 0;
+    }
+
+    return rv_exc_none;
+}
+
+default_csr_functions(scontext, rv_smode)
+
+        // Writes to scyclecmp request or unrequest STI (based on the low 32 bits of cycle)
+
+        static rv_exc_t scyclecmp_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_smode, cpu);
+    *target = cpu->csr.scyclecmp;
+    return rv_exc_none;
+}
+
+static rv_exc_t scyclecmp_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.scyclecmp = value;
+    cpu->csr.external_STIP = ((uxlen_t) cpu->csr.cycle) >= cpu->csr.scyclecmp;
+    return rv_exc_none;
+}
+static rv_exc_t scyclecmp_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.scyclecmp |= value;
+    cpu->csr.external_STIP = ((uxlen_t) cpu->csr.cycle) >= cpu->csr.scyclecmp;
+    return rv_exc_none;
+}
+static rv_exc_t scyclecmp_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_smode, cpu);
+    cpu->csr.scyclecmp &= ~value;
+    cpu->csr.external_STIP = ((uxlen_t) cpu->csr.cycle) >= cpu->csr.scyclecmp;
+    return rv_exc_none;
+}
+
+static rv_exc_t mvendorid_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mvendorid;
+    return rv_exc_none;
+}
+
+static rv_exc_t marchid_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.marchid;
+    return rv_exc_none;
+}
+
+static rv_exc_t mimpid_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mimpid;
+    return rv_exc_none;
+}
+
+static rv_exc_t mhartid_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mhartid;
+    return rv_exc_none;
+}
+
+static rv_exc_t mconfigptr_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mconfigptr;
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatus_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = (uxlen_t) cpu->csr.mstatus;
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatus_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    uint64_t val = value & rv_csr_mstatus_mask;
+
+    // if the new mpp mode would be rmode (reserved, invalid value), don't modify it
+    if (((val & rv_csr_mstatus_mpp_mask) >> 11) == rv_rmode) {
+        // zero out mpp bits from val
+        val &= ~rv_csr_mstatus_mpp_mask;
+        // set the bits to the current value
+        val |= ((uxlen_t) cpu->csr.mstatus) & rv_csr_mstatus_mpp_mask;
+    }
+
+    cpu->csr.mstatus = (cpu->csr.mstatus & 0xFFFFFFFF00000000) | val;
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatus_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    value &= rv_csr_mstatus_mask;
+
+    uint64_t new_val = ((uint64_t) value) | cpu->csr.mstatus;
+
+    // if the new mpp mode would be rmode (reserved, invalid value), don't modify it
+    if (((new_val & rv_csr_mstatus_mpp_mask) >> 11) == rv_rmode) {
+        value &= ~rv_csr_mstatus_mpp_mask;
+    }
+
+    cpu->csr.mstatus |= value;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatus_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    value &= rv_csr_mstatus_mask;
+    // Masked write
+    uint64_t new_val = (~(uint64_t) value) & cpu->csr.mstatus;
+
+    // if the new mpp mode would be rmode (reserved, invalid value), don't modify it
+    if (((new_val & rv_csr_mstatus_mpp_mask) >> 11) == rv_rmode) {
+        value &= ~rv_csr_mstatus_mpp_mask;
+    }
+
+    cpu->csr.mstatus &= ~value;
+    return rv_exc_none;
+}
+
+// Since MBE and SBE are both R/O zero and other bits re WPRI, whole mstatush is R/O zero
+static rv_exc_t mstatush_read(rv_cpu_t *cpu, csr_num_t csr, uint32_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = (uint32_t) (cpu->csr.mstatus >> 32);
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatush_write(rv_cpu_t *cpu, csr_num_t csr, uint32_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    // writes to mstatush have no effect
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatush_set(rv_cpu_t *cpu, csr_num_t csr, uint32_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    // writes to mstatush have no effect
+    return rv_exc_none;
+}
+
+static rv_exc_t mstatush_clear(rv_cpu_t *cpu, csr_num_t csr, uint32_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    // writes to mstatush have no effect
+    return rv_exc_none;
+}
+
+static rv_exc_t misa_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.misa;
+    return rv_exc_none;
+}
+
+// misa writes do nothing, we don't allow the change of extensions or MXLEN
+static rv_exc_t misa_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t misa_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t misa_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+// mmode ecall can't be delegated
+#define medeleg_mask (RV_EXCEPTIONS_MASK & ~RV_EXCEPTION_MASK(rv_exc_mmode_environment_call))
+
+static rv_exc_t medeleg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.medeleg;
+    return rv_exc_none;
+}
+
+static rv_exc_t medeleg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.medeleg = value & medeleg_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t medeleg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.medeleg |= value & medeleg_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t medeleg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.medeleg &= ~(value & medeleg_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t mideleg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mideleg;
+    return rv_exc_none;
+}
+
+// we allow only smode interrupts to be delegatable
+static rv_exc_t mideleg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mideleg = value & rv_csr_si_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mideleg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mideleg |= value & rv_csr_si_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mideleg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mideleg &= ~(value & rv_csr_si_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t mie_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mie;
+    return rv_exc_none;
+}
+
+static rv_exc_t mie_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mie = value & rv_csr_mi_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mie_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mie |= value & rv_csr_mi_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mie_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mie &= ~(value & rv_csr_mi_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t mip_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    // The SEIP bit is the logical OR of the value in MIP and the status from external interrupt controller
+    // Full explanation RISC-V Privileged spec section 3.1.9 Machine Interrupt Registers (mip and mie)
+    *target = cpu->csr.mip
+            | (cpu->csr.external_SEIP ? rv_csr_sei_mask : 0)
+            | (cpu->csr.external_STIP ? rv_csr_sti_mask : 0);
+    return rv_exc_none;
+}
+
+// M-mode interrupts are not directly writable, but all S-mode interrupts are
+#define mip_mask rv_csr_si_mask
+
+static rv_exc_t mip_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    cpu->csr.mip = value & mip_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mip_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mip |= value & mip_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mip_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mip &= ~(value & mip_mask);
+    return rv_exc_none;
+}
+
+#define mtvec_mask (~UINT32_C(2))
+
+static rv_exc_t mtvec_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mtvec;
+    return rv_exc_none;
+}
+
+static rv_exc_t mtvec_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mtvec = value & mtvec_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mtvec_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mtvec |= value & mtvec_mask;
+    return rv_exc_none;
+}
+
+static rv_exc_t mtvec_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.mtvec &= ~(value & mtvec_mask);
+    return rv_exc_none;
+}
+
+default_csr_functions(mcounteren, rv_mmode)
+
+        default_csr_functions(mscratch, rv_mmode)
+                default_csr_functions(mepc, rv_mmode)
+
+                        static rv_exc_t mcause_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mcause;
+    return rv_exc_none;
+}
+
+static rv_exc_t mcause_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    if (is_exception_code(value)) {
+        cpu->csr.mcause = value;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+    return rv_exc_none;
+}
+
+static rv_exc_t mcause_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+
+    uxlen_t val = cpu->csr.mcause | value;
+
+    if (is_exception_code(val)) {
+        cpu->csr.mcause = val;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+    return rv_exc_none;
+}
+
+static rv_exc_t mcause_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    uxlen_t val = cpu->csr.mcause & ~value;
+
+    if (is_exception_code(val)) {
+        cpu->csr.mcause = val;
+    } else {
+        return rv_exc_illegal_instruction;
+    }
+    return rv_exc_none;
+}
+
+default_csr_functions(mtval, rv_mmode)
+
+        static rv_exc_t mtinst_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtinst_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtinst_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtinst_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtval2_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtval2_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtval2_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mtval2_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+#define menvcfg_fiom_mask UINT32_C(1)
+
+static rv_exc_t menvcfg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = (uxlen_t) cpu->csr.menvcfg;
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    // TODO: Reconsider this masking
+    cpu->csr.menvcfg = (cpu->csr.menvcfg & 0xFFFFFFFF00000000) | (value & menvcfg_fiom_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    cpu->csr.menvcfg |= (uint64_t) (value & menvcfg_fiom_mask);
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    // Writing to unwritable fields
+    cpu->csr.menvcfg &= ~((uint64_t) (value & menvcfg_fiom_mask));
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfgh_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.menvcfg >> 32;
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfgh_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfgh_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t menvcfgh_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+// mseccfg(h) do nothing as of now, so they are read-only 0
+static rv_exc_t mseccfg_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = cpu->csr.mseccfg;
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfg_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfg_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfg_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfgh_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    minimal_privilege(rv_mmode, cpu);
+    *target = 0;
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfgh_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfgh_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t mseccfgh_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    minimal_privilege(rv_mmode, cpu);
+    return rv_exc_none;
+}
+
+static rv_exc_t tselect_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tselect_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tselect_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tselect_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata1_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata1_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata1_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata1_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata2_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata2_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata2_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata2_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata3_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata3_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata3_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t tdata3_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mcontext_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mcontext_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mcontext_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t mcontext_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dcsr_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dcsr_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dcsr_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dcsr_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dpc_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dpc_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dpc_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dpc_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch0_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch0_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch0_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch0_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch1_read(rv_cpu_t *cpu, csr_num_t csr, uxlen_t *target)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch1_write(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch1_set(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+static rv_exc_t dscratch1_clear(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value)
+{
+    return rv_exc_illegal_instruction;
+}
+
+/** Retrieves the CSR ops for the given csr*/
+static csr_ops_t get_csr_ops(csr_num_t csr)
+{
+    csr_ops_t ops = {
+        .read = invalid_read,
+        .write = invalid_write,
+        .set = invalid_write,
+        .clear = invalid_write
+    };
+
+#define default_case(csr) \
+    case csr_##csr: { \
+        ops.read = csr##_read; \
+        ops.write = csr##_write; \
+        ops.set = csr##_set; \
+        ops.clear = csr##_clear; \
+        break; \
+    }
+
+#define read_only_case(csr) \
+    case csr_##csr: { \
+        ops.read = csr##_read; \
+        ops.write = invalid_write; \
+        ops.set = invalid_write; \
+        ops.clear = invalid_write; \
+        break; \
+    }
+
+    switch (csr) {
+    case (csr_cycle):
+    case (csr_time):
+    case (csr_instret):
+    case (csr_hpmcounter3):
+    case (csr_hpmcounter4):
+    case (csr_hpmcounter5):
+    case (csr_hpmcounter6):
+    case (csr_hpmcounter7):
+    case (csr_hpmcounter8):
+    case (csr_hpmcounter9):
+    case (csr_hpmcounter10):
+    case (csr_hpmcounter11):
+    case (csr_hpmcounter12):
+    case (csr_hpmcounter13):
+    case (csr_hpmcounter14):
+    case (csr_hpmcounter15):
+    case (csr_hpmcounter16):
+    case (csr_hpmcounter17):
+    case (csr_hpmcounter18):
+    case (csr_hpmcounter19):
+    case (csr_hpmcounter20):
+    case (csr_hpmcounter21):
+    case (csr_hpmcounter22):
+    case (csr_hpmcounter23):
+    case (csr_hpmcounter24):
+    case (csr_hpmcounter25):
+    case (csr_hpmcounter26):
+    case (csr_hpmcounter27):
+    case (csr_hpmcounter28):
+    case (csr_hpmcounter29):
+    case (csr_hpmcounter30):
+    case (csr_hpmcounter31):
+    case (csr_cycleh):
+    case (csr_timeh):
+    case (csr_instreth):
+    case (csr_hpmcounter3h):
+    case (csr_hpmcounter4h):
+    case (csr_hpmcounter5h):
+    case (csr_hpmcounter6h):
+    case (csr_hpmcounter7h):
+    case (csr_hpmcounter8h):
+    case (csr_hpmcounter9h):
+    case (csr_hpmcounter10h):
+    case (csr_hpmcounter11h):
+    case (csr_hpmcounter12h):
+    case (csr_hpmcounter13h):
+    case (csr_hpmcounter14h):
+    case (csr_hpmcounter15h):
+    case (csr_hpmcounter16h):
+    case (csr_hpmcounter17h):
+    case (csr_hpmcounter18h):
+    case (csr_hpmcounter19h):
+    case (csr_hpmcounter20h):
+    case (csr_hpmcounter21h):
+    case (csr_hpmcounter22h):
+    case (csr_hpmcounter23h):
+    case (csr_hpmcounter24h):
+    case (csr_hpmcounter25h):
+    case (csr_hpmcounter26h):
+    case (csr_hpmcounter27h):
+    case (csr_hpmcounter28h):
+    case (csr_hpmcounter29h):
+    case (csr_hpmcounter30h):
+    case (csr_hpmcounter31h):
+    case (csr_mcycle):
+    case (csr_minstret):
+    case (csr_mhpmcounter3):
+    case (csr_mhpmcounter4):
+    case (csr_mhpmcounter5):
+    case (csr_mhpmcounter6):
+    case (csr_mhpmcounter7):
+    case (csr_mhpmcounter8):
+    case (csr_mhpmcounter9):
+    case (csr_mhpmcounter10):
+    case (csr_mhpmcounter11):
+    case (csr_mhpmcounter12):
+    case (csr_mhpmcounter13):
+    case (csr_mhpmcounter14):
+    case (csr_mhpmcounter15):
+    case (csr_mhpmcounter16):
+    case (csr_mhpmcounter17):
+    case (csr_mhpmcounter18):
+    case (csr_mhpmcounter19):
+    case (csr_mhpmcounter20):
+    case (csr_mhpmcounter21):
+    case (csr_mhpmcounter22):
+    case (csr_mhpmcounter23):
+    case (csr_mhpmcounter24):
+    case (csr_mhpmcounter25):
+    case (csr_mhpmcounter26):
+    case (csr_mhpmcounter27):
+    case (csr_mhpmcounter28):
+    case (csr_mhpmcounter29):
+    case (csr_mhpmcounter30):
+    case (csr_mhpmcounter31):
+    case (csr_mcycleh):
+    case (csr_minstreth):
+    case (csr_mhpmcounter3h):
+    case (csr_mhpmcounter4h):
+    case (csr_mhpmcounter5h):
+    case (csr_mhpmcounter6h):
+    case (csr_mhpmcounter7h):
+    case (csr_mhpmcounter8h):
+    case (csr_mhpmcounter9h):
+    case (csr_mhpmcounter10h):
+    case (csr_mhpmcounter11h):
+    case (csr_mhpmcounter12h):
+    case (csr_mhpmcounter13h):
+    case (csr_mhpmcounter14h):
+    case (csr_mhpmcounter15h):
+    case (csr_mhpmcounter16h):
+    case (csr_mhpmcounter17h):
+    case (csr_mhpmcounter18h):
+    case (csr_mhpmcounter19h):
+    case (csr_mhpmcounter20h):
+    case (csr_mhpmcounter21h):
+    case (csr_mhpmcounter22h):
+    case (csr_mhpmcounter23h):
+    case (csr_mhpmcounter24h):
+    case (csr_mhpmcounter25h):
+    case (csr_mhpmcounter26h):
+    case (csr_mhpmcounter27h):
+    case (csr_mhpmcounter28h):
+    case (csr_mhpmcounter29h):
+    case (csr_mhpmcounter30h):
+    case (csr_mhpmcounter31h): {
+        ops.read = counter_read;
+        ops.write = counter_write;
+        ops.set = counter_set;
+        ops.clear = counter_clear;
+        break;
+    }
+
+    case (csr_mhpmevent3):
+    case (csr_mhpmevent4):
+    case (csr_mhpmevent5):
+    case (csr_mhpmevent6):
+    case (csr_mhpmevent7):
+    case (csr_mhpmevent8):
+    case (csr_mhpmevent9):
+    case (csr_mhpmevent10):
+    case (csr_mhpmevent11):
+    case (csr_mhpmevent12):
+    case (csr_mhpmevent13):
+    case (csr_mhpmevent14):
+    case (csr_mhpmevent15):
+    case (csr_mhpmevent16):
+    case (csr_mhpmevent17):
+    case (csr_mhpmevent18):
+    case (csr_mhpmevent19):
+    case (csr_mhpmevent20):
+    case (csr_mhpmevent21):
+    case (csr_mhpmevent22):
+    case (csr_mhpmevent23):
+    case (csr_mhpmevent24):
+    case (csr_mhpmevent25):
+    case (csr_mhpmevent26):
+    case (csr_mhpmevent27):
+    case (csr_mhpmevent28):
+    case (csr_mhpmevent29):
+    case (csr_mhpmevent30):
+    case (csr_mhpmevent31): {
+        ops.read = mhpmevent_read;
+        ops.write = mhpmevent_write;
+        ops.set = mhpmevent_set;
+        ops.clear = mhpmevent_clear;
+        break;
+    }
+
+    case (csr_pmpcfg0):
+    case (csr_pmpcfg1):
+    case (csr_pmpcfg2):
+    case (csr_pmpcfg3):
+    case (csr_pmpcfg4):
+    case (csr_pmpcfg5):
+    case (csr_pmpcfg6):
+    case (csr_pmpcfg7):
+    case (csr_pmpcfg8):
+    case (csr_pmpcfg9):
+    case (csr_pmpcfg10):
+    case (csr_pmpcfg11):
+    case (csr_pmpcfg12):
+    case (csr_pmpcfg13):
+    case (csr_pmpcfg14):
+    case (csr_pmpcfg15): {
+        ops.read = pmpcfg_read;
+        ops.write = pmpcfg_write;
+        ops.set = pmpcfg_set;
+        ops.clear = pmpcfg_clear;
+        break;
+    }
+
+    case (csr_pmpaddr0):
+    case (csr_pmpaddr1):
+    case (csr_pmpaddr2):
+    case (csr_pmpaddr3):
+    case (csr_pmpaddr4):
+    case (csr_pmpaddr5):
+    case (csr_pmpaddr6):
+    case (csr_pmpaddr7):
+    case (csr_pmpaddr8):
+    case (csr_pmpaddr9):
+    case (csr_pmpaddr10):
+    case (csr_pmpaddr11):
+    case (csr_pmpaddr12):
+    case (csr_pmpaddr13):
+    case (csr_pmpaddr14):
+    case (csr_pmpaddr15):
+    case (csr_pmpaddr16):
+    case (csr_pmpaddr17):
+    case (csr_pmpaddr18):
+    case (csr_pmpaddr19):
+    case (csr_pmpaddr20):
+    case (csr_pmpaddr21):
+    case (csr_pmpaddr22):
+    case (csr_pmpaddr23):
+    case (csr_pmpaddr24):
+    case (csr_pmpaddr25):
+    case (csr_pmpaddr26):
+    case (csr_pmpaddr27):
+    case (csr_pmpaddr28):
+    case (csr_pmpaddr29):
+    case (csr_pmpaddr30):
+    case (csr_pmpaddr31):
+    case (csr_pmpaddr32):
+    case (csr_pmpaddr33):
+    case (csr_pmpaddr34):
+    case (csr_pmpaddr35):
+    case (csr_pmpaddr36):
+    case (csr_pmpaddr37):
+    case (csr_pmpaddr38):
+    case (csr_pmpaddr39):
+    case (csr_pmpaddr40):
+    case (csr_pmpaddr41):
+    case (csr_pmpaddr42):
+    case (csr_pmpaddr43):
+    case (csr_pmpaddr44):
+    case (csr_pmpaddr45):
+    case (csr_pmpaddr46):
+    case (csr_pmpaddr47):
+    case (csr_pmpaddr48):
+    case (csr_pmpaddr49):
+    case (csr_pmpaddr50):
+    case (csr_pmpaddr51):
+    case (csr_pmpaddr52):
+    case (csr_pmpaddr53):
+    case (csr_pmpaddr54):
+    case (csr_pmpaddr55):
+    case (csr_pmpaddr56):
+    case (csr_pmpaddr57):
+    case (csr_pmpaddr58):
+    case (csr_pmpaddr59):
+    case (csr_pmpaddr60):
+    case (csr_pmpaddr61):
+    case (csr_pmpaddr62):
+    case (csr_pmpaddr63): {
+        ops.read = pmpaddr_read;
+        ops.write = pmpaddr_write;
+        ops.set = pmpaddr_set;
+        ops.clear = pmpaddr_clear;
+        break;
+    }
+
+        // clang-format off
+
+    default_case(mcountinhibit)
+
+    default_case(sstatus)
+
+    default_case(sie)
+    default_case(stvec)
+    default_case(scounteren)
+
+    default_case(senvcfg)
+
+    default_case(sscratch)
+    default_case(sepc)
+    default_case(scause)
+    default_case(stval)
+    default_case(sip)
+    default_case(satp)
+    default_case(scontext)
+    default_case(scyclecmp)
+
+    read_only_case(mvendorid)
+    read_only_case(marchid)
+    read_only_case(mimpid)
+    read_only_case(mhartid)
+    read_only_case(mconfigptr)
+
+    default_case(mstatus)
+    #if XLEN == 32
+    default_case(mstatush)
+    #endif
+
+
+    default_case(misa)
+    default_case(medeleg)
+    default_case(mideleg)
+    default_case(mie)
+    default_case(mtvec)
+    default_case(mcounteren)
+
+    default_case(mscratch)
+    default_case(mepc)
+    default_case(mcause)
+    default_case(mtval)
+    default_case(mip)
+    default_case(mtinst)
+    default_case(mtval2)
+
+    default_case(menvcfg)
+    default_case(menvcfgh)
+    default_case(mseccfg)
+    default_case(mseccfgh)
+
+    default_case(tselect)
+    default_case(tdata1)
+    default_case(tdata2)
+    default_case(tdata3)
+    default_case(mcontext)
+    default_case(dcsr)
+    default_case(dpc)
+    default_case(dscratch0)
+    default_case(dscratch1)
+
+        // clang-format on
+    }
+
+    return ops;
+
+#undef default_case
+#undef read_only_case
+}
+
+/**
+ * @brief Reads the old value from the CSR, then writes the specified value
+ *
+ * @param cpu The cpu on which this operation is done
+ * @param csr The csr on which this operation is done
+ * @param value The value to be written
+ * @param read_target The location where the read original value will be stored on success
+ * @param read Whether the read should be done
+ * @return rv_exc_t The exception code
+ */
+static rv_exc_t rv_csr_rw(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool read)
+{
+    csr_ops_t ops = get_csr_ops(csr);
+    rv_exc_t ex = rv_exc_none;
+    uxlen_t temp_read_target = 0;
+
+    if (read) {
+        ex = ops.read(cpu, csr, &temp_read_target);
+    }
+
+    if (ex == rv_exc_none) {
+        ex = ops.write(cpu, csr, value);
+    }
+
+    if (ex == rv_exc_none) {
+        *read_target = temp_read_target;
+    }
+
+    return ex;
+}
+
+/**
+ * @brief Reads the old value from the CSR, then sets the specified bits
+ *
+ * @param cpu The cpu on which this operation is done
+ * @param csr The csr on which this operation is done
+ * @param value The value specifying which bits to set
+ * @param read_target The location where the read original value will be stored on success
+ * @param write Whether the bits should be set
+ * @return rv_exc_t The exception code
+ */
+static rv_exc_t rv_csr_rs(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool write)
+{
+    csr_ops_t ops = get_csr_ops(csr);
+
+    uxlen_t temp_read_target = 0;
+
+    rv_exc_t ex = ops.read(cpu, csr, &temp_read_target);
+
+    if (ex == rv_exc_none && write) {
+        ex = ops.set(cpu, csr, value);
+    }
+
+    if (ex == rv_exc_none) {
+        *read_target = temp_read_target;
+    }
+
+    return ex;
+}
+
+/**
+ * @brief Reads the old value from the CSR, then clears the specified bits
+ *
+ * @param cpu The cpu on which this operation is done
+ * @param csr The csr on which this operation is done
+ * @param value The value specifying which bits to clear
+ * @param read_target The location where the read original value will be stored on success
+ * @param write Whether the bits should be cleared
+ * @return rv_exc_t The exception code
+ */
+static rv_exc_t rv_csr_rc(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool write)
+{
+
+    csr_ops_t ops = get_csr_ops(csr);
+    uxlen_t temp_read_target = 0;
+    rv_exc_t ex = ops.read(cpu, csr, &temp_read_target);
+
+    if (ex == rv_exc_none && write) {
+        ex = ops.clear(cpu, csr, value);
+    }
+
+    if (ex == rv_exc_none) {
+        *read_target = temp_read_target;
+    }
+
+    return ex;
+}

--- a/src/device/cpu/riscv_rv_ima/csr.h
+++ b/src/device/cpu/riscv_rv_ima/csr.h
@@ -1,0 +1,616 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V CSR
+ *
+ */
+
+#ifndef RISCV_RV_CSR_H_
+#define RISCV_RV_CSR_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "exception.h"
+#include "types.h"
+
+/**
+ * The numerical codes of CSRs
+ */
+typedef enum {
+
+    /********************************
+     * Unprivileged Counters/Timers *
+     ********************************/
+
+    csr_cycle = 0xC00, // Cycle counter for RCCYCLE
+    csr_time = 0xC01, // Timer (real time) for RDTIME
+    csr_instret = 0xC02, // Instruction-retired counter for RDINSTRET
+
+    /* Architecture-Defined Performance-Monitoring Counters (lower 32 bits) */
+    csr_hpmcounter3 = 0xC03,
+    csr_hpmcounter4 = 0xC04,
+    csr_hpmcounter5 = 0xC05,
+    csr_hpmcounter6 = 0xC06,
+    csr_hpmcounter7 = 0xC07,
+    csr_hpmcounter8 = 0xC08,
+    csr_hpmcounter9 = 0xC09,
+    csr_hpmcounter10 = 0xC0A,
+    csr_hpmcounter11 = 0xC0B,
+    csr_hpmcounter12 = 0xC0C,
+    csr_hpmcounter13 = 0xC0D,
+    csr_hpmcounter14 = 0xC0E,
+    csr_hpmcounter15 = 0xC0F,
+    csr_hpmcounter16 = 0xC10,
+    csr_hpmcounter17 = 0xC11,
+    csr_hpmcounter18 = 0xC12,
+    csr_hpmcounter19 = 0xC13,
+    csr_hpmcounter20 = 0xC14,
+    csr_hpmcounter21 = 0xC15,
+    csr_hpmcounter22 = 0xC16,
+    csr_hpmcounter23 = 0xC17,
+    csr_hpmcounter24 = 0xC18,
+    csr_hpmcounter25 = 0xC19,
+    csr_hpmcounter26 = 0xC1A,
+    csr_hpmcounter27 = 0xC1B,
+    csr_hpmcounter28 = 0xC1C,
+    csr_hpmcounter29 = 0xC1D,
+    csr_hpmcounter30 = 0xC1E,
+    csr_hpmcounter31 = 0xC1F,
+
+    /* Upper 32 bits of timers/counters */
+    csr_cycleh = 0xC80,
+    csr_timeh = 0xC81,
+    csr_instreth = 0xC82,
+    csr_hpmcounter3h = 0xC83,
+    csr_hpmcounter4h = 0xC84,
+    csr_hpmcounter5h = 0xC85,
+    csr_hpmcounter6h = 0xC86,
+    csr_hpmcounter7h = 0xC87,
+    csr_hpmcounter8h = 0xC88,
+    csr_hpmcounter9h = 0xC89,
+    csr_hpmcounter10h = 0xC8A,
+    csr_hpmcounter11h = 0xC8B,
+    csr_hpmcounter12h = 0xC8C,
+    csr_hpmcounter13h = 0xC8D,
+    csr_hpmcounter14h = 0xC8E,
+    csr_hpmcounter15h = 0xC8F,
+    csr_hpmcounter16h = 0xC90,
+    csr_hpmcounter17h = 0xC91,
+    csr_hpmcounter18h = 0xC92,
+    csr_hpmcounter19h = 0xC93,
+    csr_hpmcounter20h = 0xC94,
+    csr_hpmcounter21h = 0xC95,
+    csr_hpmcounter22h = 0xC96,
+    csr_hpmcounter23h = 0xC97,
+    csr_hpmcounter24h = 0xC98,
+    csr_hpmcounter25h = 0xC99,
+    csr_hpmcounter26h = 0xC9A,
+    csr_hpmcounter27h = 0xC9B,
+    csr_hpmcounter28h = 0xC9C,
+    csr_hpmcounter29h = 0xC9D,
+    csr_hpmcounter30h = 0xC9E,
+    csr_hpmcounter31h = 0xC9F,
+
+    /*************************
+     * Supervisor level CSRs *
+     *************************/
+
+    /* Trap Setup */
+    csr_sstatus = 0x100, // Supervisor status register
+    csr_sie = 0x104, // Sup. interrupt-enable reg.
+    csr_stvec = 0x105, // Sup. trap handler base address
+    csr_scounteren = 0x106, // Sup. counter enable
+
+    /* Configuration */
+    csr_senvcfg = 0x10A, // Sup. environment configuration reg.
+
+    /* Trap Handling */
+    csr_sscratch = 0x140, // Scratch reg. for sup. tram handlers
+    csr_sepc = 0x141, // Sup. exception program counter
+    csr_scause = 0x142, // Sup. trap cause
+    csr_stval = 0x143, // Sup. bad address or instruction
+    csr_sip = 0x144, // Sup. interrupt pending
+
+    /* Address Translation and Protection */
+    csr_satp = 0x180, // Sup. addr. translation and protection
+
+    /* Debug/Trace */
+    csr_scontext = 0x5A8, // Supervisor-mode context reg.
+
+    /* Custom */
+    csr_scyclecmp = 0x5C0, // Supervisor Cycle compare (r/w)
+
+    /**********************
+     * Machine level CSRs *
+     **********************/
+
+    /* Machine information */
+    csr_mvendorid = 0xF11, // Vendor id
+    csr_marchid = 0xF12, // Architecture id
+    csr_mimpid = 0xF13, // Implementation id
+    csr_mhartid = 0xF14, // Hardware thread id (procno)
+    csr_mconfigptr = 0xF15, // Pointer to configuration data structure
+
+    /* Trap Setup */
+    csr_mstatus = 0x300, // Machine status register
+    csr_misa = 0x301, // ISA and extensions
+    csr_medeleg = 0x302, // Mch. exception delegation reg.
+    csr_mideleg = 0x303, // Mch. interrupt delegation reg.
+    csr_mie = 0x304, // Mch. interrupt-enable reg.
+    csr_mtvec = 0x305, // Mch. trap-handler base addr.
+    csr_mcounteren = 0x306, // Mch. counter enable
+    csr_mstatush = 0x310, // Additional mch. status register
+
+    /* Trap Handling */
+    csr_mscratch = 0x340, // Scratch register for mch. trap handlers
+    csr_mepc = 0x341, // Mch. exception pc
+    csr_mcause = 0x342, // Mch. trap cause
+    csr_mtval = 0x343, // Mch. bad addr. or instr.
+    csr_mip = 0x344, // Mch. interrupt pending
+    csr_mtinst = 0x34A, // Mch. trap instruction (transformed)
+    csr_mtval2 = 0x34B, // Mch. bad guest physical addr.
+
+    /* Machine Configuration */
+    csr_menvcfg = 0x30A, // Mch. environment conf. reg.
+    csr_menvcfgh = 0x31A, // Additional mch. env. conf. reg.
+    csr_mseccfg = 0x747, // Mch. security conf. reg.
+    csr_mseccfgh = 0x757, // Additional mch. security conf. reg.
+
+    /* Memory Protection */
+
+    /* Phys. mem. protection configuration */
+    csr_pmpcfg0 = 0x3A0,
+    csr_pmpcfg1 = 0x3A1,
+    csr_pmpcfg2 = 0x3A2,
+    csr_pmpcfg3 = 0x3A3,
+    csr_pmpcfg4 = 0x3A4,
+    csr_pmpcfg5 = 0x3A5,
+    csr_pmpcfg6 = 0x3A6,
+    csr_pmpcfg7 = 0x3A7,
+    csr_pmpcfg8 = 0x3A8,
+    csr_pmpcfg9 = 0x3A9,
+    csr_pmpcfg10 = 0x3AA,
+    csr_pmpcfg11 = 0x3AB,
+    csr_pmpcfg12 = 0x3AC,
+    csr_pmpcfg13 = 0x3AD,
+    csr_pmpcfg14 = 0x3AE,
+    csr_pmpcfg15 = 0x3AF,
+
+    /* Phys. mem. protection address */
+    csr_pmpaddr0 = 0x3B0,
+    csr_pmpaddr1 = 0x3B1,
+    csr_pmpaddr2 = 0x3B2,
+    csr_pmpaddr3 = 0x3B3,
+    csr_pmpaddr4 = 0x3B4,
+    csr_pmpaddr5 = 0x3B5,
+    csr_pmpaddr6 = 0x3B6,
+    csr_pmpaddr7 = 0x3B7,
+    csr_pmpaddr8 = 0x3B8,
+    csr_pmpaddr9 = 0x3B9,
+    csr_pmpaddr10 = 0x3BA,
+    csr_pmpaddr11 = 0x3BB,
+    csr_pmpaddr12 = 0x3BC,
+    csr_pmpaddr13 = 0x3BD,
+    csr_pmpaddr14 = 0x3BE,
+    csr_pmpaddr15 = 0x3BF,
+    csr_pmpaddr16 = 0x3C0,
+    csr_pmpaddr17 = 0x3C1,
+    csr_pmpaddr18 = 0x3C2,
+    csr_pmpaddr19 = 0x3C3,
+    csr_pmpaddr20 = 0x3C4,
+    csr_pmpaddr21 = 0x3C5,
+    csr_pmpaddr22 = 0x3C6,
+    csr_pmpaddr23 = 0x3C7,
+    csr_pmpaddr24 = 0x3C8,
+    csr_pmpaddr25 = 0x3C9,
+    csr_pmpaddr26 = 0x3CA,
+    csr_pmpaddr27 = 0x3CB,
+    csr_pmpaddr28 = 0x3CC,
+    csr_pmpaddr29 = 0x3CD,
+    csr_pmpaddr30 = 0x3CE,
+    csr_pmpaddr31 = 0x3CF,
+    csr_pmpaddr32 = 0x3D0,
+    csr_pmpaddr33 = 0x3D1,
+    csr_pmpaddr34 = 0x3D2,
+    csr_pmpaddr35 = 0x3D3,
+    csr_pmpaddr36 = 0x3D4,
+    csr_pmpaddr37 = 0x3D5,
+    csr_pmpaddr38 = 0x3D6,
+    csr_pmpaddr39 = 0x3D7,
+    csr_pmpaddr40 = 0x3D8,
+    csr_pmpaddr41 = 0x3D9,
+    csr_pmpaddr42 = 0x3DA,
+    csr_pmpaddr43 = 0x3DB,
+    csr_pmpaddr44 = 0x3DC,
+    csr_pmpaddr45 = 0x3DD,
+    csr_pmpaddr46 = 0x3DE,
+    csr_pmpaddr47 = 0x3DF,
+    csr_pmpaddr48 = 0x3E0,
+    csr_pmpaddr49 = 0x3E1,
+    csr_pmpaddr50 = 0x3E2,
+    csr_pmpaddr51 = 0x3E3,
+    csr_pmpaddr52 = 0x3E4,
+    csr_pmpaddr53 = 0x3E5,
+    csr_pmpaddr54 = 0x3E6,
+    csr_pmpaddr55 = 0x3E7,
+    csr_pmpaddr56 = 0x3E8,
+    csr_pmpaddr57 = 0x3E9,
+    csr_pmpaddr58 = 0x3EA,
+    csr_pmpaddr59 = 0x3EB,
+    csr_pmpaddr60 = 0x3EC,
+    csr_pmpaddr61 = 0x3ED,
+    csr_pmpaddr62 = 0x3EE,
+    csr_pmpaddr63 = 0x3EF,
+
+    /* Machine Counters/Timers */
+
+    csr_mcycle = 0xB00, // Machine cycle counter
+    csr_minstret = 0xB02, // Machine intructions retired counter
+
+    /* Machine performance-monitoring counters (lower 32 bits) */
+    csr_mhpmcounter3 = 0xB03,
+    csr_mhpmcounter4 = 0xB04,
+    csr_mhpmcounter5 = 0xB05,
+    csr_mhpmcounter6 = 0xB06,
+    csr_mhpmcounter7 = 0xB07,
+    csr_mhpmcounter8 = 0xB08,
+    csr_mhpmcounter9 = 0xB09,
+    csr_mhpmcounter10 = 0xB0A,
+    csr_mhpmcounter11 = 0xB0B,
+    csr_mhpmcounter12 = 0xB0C,
+    csr_mhpmcounter13 = 0xB0D,
+    csr_mhpmcounter14 = 0xB0E,
+    csr_mhpmcounter15 = 0xB0F,
+    csr_mhpmcounter16 = 0xB10,
+    csr_mhpmcounter17 = 0xB11,
+    csr_mhpmcounter18 = 0xB12,
+    csr_mhpmcounter19 = 0xB13,
+    csr_mhpmcounter20 = 0xB14,
+    csr_mhpmcounter21 = 0xB15,
+    csr_mhpmcounter22 = 0xB16,
+    csr_mhpmcounter23 = 0xB17,
+    csr_mhpmcounter24 = 0xB18,
+    csr_mhpmcounter25 = 0xB19,
+    csr_mhpmcounter26 = 0xB1A,
+    csr_mhpmcounter27 = 0xB1B,
+    csr_mhpmcounter28 = 0xB1C,
+    csr_mhpmcounter29 = 0xB1D,
+    csr_mhpmcounter30 = 0xB1E,
+    csr_mhpmcounter31 = 0xB1F,
+
+    /* Upper 32-bit of machine counters */
+    csr_mcycleh = 0xB80,
+    csr_minstreth = 0xB82,
+    csr_mhpmcounter3h = 0xB83,
+    csr_mhpmcounter4h = 0xB84,
+    csr_mhpmcounter5h = 0xB85,
+    csr_mhpmcounter6h = 0xB86,
+    csr_mhpmcounter7h = 0xB87,
+    csr_mhpmcounter8h = 0xB88,
+    csr_mhpmcounter9h = 0xB89,
+    csr_mhpmcounter10h = 0xB8A,
+    csr_mhpmcounter11h = 0xB8B,
+    csr_mhpmcounter12h = 0xB8C,
+    csr_mhpmcounter13h = 0xB8D,
+    csr_mhpmcounter14h = 0xB8E,
+    csr_mhpmcounter15h = 0xB8F,
+    csr_mhpmcounter16h = 0xB90,
+    csr_mhpmcounter17h = 0xB91,
+    csr_mhpmcounter18h = 0xB92,
+    csr_mhpmcounter19h = 0xB93,
+    csr_mhpmcounter20h = 0xB94,
+    csr_mhpmcounter21h = 0xB95,
+    csr_mhpmcounter22h = 0xB96,
+    csr_mhpmcounter23h = 0xB97,
+    csr_mhpmcounter24h = 0xB98,
+    csr_mhpmcounter25h = 0xB99,
+    csr_mhpmcounter26h = 0xB9A,
+    csr_mhpmcounter27h = 0xB9B,
+    csr_mhpmcounter28h = 0xB9C,
+    csr_mhpmcounter29h = 0xB9D,
+    csr_mhpmcounter30h = 0xB9E,
+    csr_mhpmcounter31h = 0xB9F,
+
+    /* Counter Setup */
+    csr_mcountinhibit = 0x320, // Mch. counter-inhibit reg.
+
+    /* Machine performance-monitoring event selectors */
+    csr_mhpmevent3 = 0x323,
+    csr_mhpmevent4 = 0x324,
+    csr_mhpmevent5 = 0x325,
+    csr_mhpmevent6 = 0x326,
+    csr_mhpmevent7 = 0x327,
+    csr_mhpmevent8 = 0x328,
+    csr_mhpmevent9 = 0x329,
+    csr_mhpmevent10 = 0x32A,
+    csr_mhpmevent11 = 0x32B,
+    csr_mhpmevent12 = 0x32C,
+    csr_mhpmevent13 = 0x32D,
+    csr_mhpmevent14 = 0x32E,
+    csr_mhpmevent15 = 0x32F,
+    csr_mhpmevent16 = 0x330,
+    csr_mhpmevent17 = 0x331,
+    csr_mhpmevent18 = 0x332,
+    csr_mhpmevent19 = 0x333,
+    csr_mhpmevent20 = 0x334,
+    csr_mhpmevent21 = 0x335,
+    csr_mhpmevent22 = 0x336,
+    csr_mhpmevent23 = 0x337,
+    csr_mhpmevent24 = 0x338,
+    csr_mhpmevent25 = 0x339,
+    csr_mhpmevent26 = 0x33A,
+    csr_mhpmevent27 = 0x33B,
+    csr_mhpmevent28 = 0x33C,
+    csr_mhpmevent29 = 0x33D,
+    csr_mhpmevent30 = 0x33E,
+    csr_mhpmevent31 = 0x33F,
+
+    /* Debug/Trace */
+    csr_tselect = 0x7A0, // Debug/Trace trigger register select
+    csr_tdata1 = 0x7A1, // First Debug/Trace trigger data register
+    csr_tdata2 = 0x7A2, // Second Debug/Trace trigger data register
+    csr_tdata3 = 0x7A3, // Third Debug/Trace trigger data register
+    csr_mcontext = 0x7A8, // Machine-mode context reg.
+
+    /* Debug Mode */
+    csr_dcsr = 0x7B0, // Dbg. control and status reg.
+    csr_dpc = 0x7B1, // Dbg. pc
+    csr_dscratch0 = 0x7B2, // Dbg. scratch reg. 0
+    csr_dscratch1 = 0x7B3 // Dbg. scratch reg. 1
+
+} csr_num_t;
+
+/**
+ * Types of HPM events
+ */
+typedef enum {
+    hpm_no_event,
+    hpm_u_cycles,
+    hpm_s_cycles,
+    hpm_r_cycles, //! RESERVED
+    hpm_m_cycles,
+    hpm_w_cycles,
+    // rest TBA
+    hpm_event_count // Last enum member holding the count
+} rv_csr_hpm_event_t;
+
+/**
+ * Structure holding CSR data
+ */
+typedef struct {
+    /* Counters/Timers */
+    uint64_t cycle;
+    uint64_t instret;
+
+    uint64_t hpmcounters[29];
+
+    /* Event selectors */
+    uxlen_t hpmevents[29];
+
+    /* Machine-level registers */
+
+    /* information */
+    uxlen_t misa;
+    uxlen_t mvendorid;
+    uxlen_t marchid;
+    uxlen_t mimpid;
+    uxlen_t mhartid;
+    uxlen_t mconfigptr;
+
+    uint64_t mstatus; // subset shared with supervisor level
+
+    /* trap handling */
+    uxlen_t mtvec;
+    uxlen_t medeleg;
+    uxlen_t mideleg;
+    uxlen_t mip;
+    uxlen_t mie;
+    uxlen_t mscratch;
+    uxlen_t mepc;
+    uxlen_t mcause;
+    uxlen_t mtval;
+
+    /* counter control*/
+    uxlen_t mcounteren;
+    uxlen_t mcountinhibit;
+
+    /* configs */
+    uint64_t menvcfg;
+    uxlen_t mseccfg;
+
+    /* debug/trace */
+    uxlen_t mcontext;
+
+    /* physical memory protection */
+    uint8_t pmpcfgs[64];
+    uxlen_t pmpaddrs[64];
+
+    /* Supervisor level registers*/
+
+    // sstatus shared witm m-mode
+    uxlen_t stvec;
+    // sip and sie shared with m-mode
+
+    uxlen_t scounteren;
+
+    /* Trap handling */
+    uxlen_t sscratch;
+    uxlen_t sepc;
+    uxlen_t scause;
+    uxlen_t stval;
+
+    /* config */
+    uxlen_t senvcfg;
+
+    /* Address translation */
+    uxlen_t satp;
+
+    /* Debug */
+    uxlen_t scontext;
+
+    /* Extra fields used for implementation purposes */
+
+    // next value for stval/mtval
+    uxlen_t tval_next;
+
+    // Keeps whether SEI is pending from an external source
+    // Full explanation RISC-V Privileged spec section 3.1.9 Machine Interrupt Registers (mip and mie)
+    bool external_SEIP;
+
+    // Value of memory-mapped register mtime
+    uint64_t mtime;
+    // The timestamp of the last clock cycle
+    uint64_t last_tick_time;
+    // Value of memory-mapped register mtimecmp
+    uint64_t mtimecmp;
+
+    // Supervisor cycle compare used for STI
+    //? is XLEN=32 for rv32 enough?
+    uxlen_t scyclecmp;
+    bool external_STIP;
+
+    // Number of bits used in the ASID field of SATP CSR - Should be between 0 and 9.
+    unsigned asid_len;
+
+} rv_csr_t;
+
+#define RV_START_ADDRESS XLEN_C(0xF0000000)
+#define RV_MTIME_ADDRESS XLEN_C(0xFF000000)
+#define RV_MTIMECMP_ADDRESS XLEN_C(0xFF000008)
+
+#define RV_A_EXTENSION_BITS XLEN_C(1 << 0)
+#define RV_C_EXTENSION_BITS XLEN_C(1 << 2)
+#define RV_D_EXTENSION_BITS XLEN_C(1 << 3)
+#define RV_E_EXTENSION_BITS XLEN_C(1 << 4)
+#define RV_F_EXTENSION_BITS XLEN_C(1 << 5)
+#define RV_H_EXTENSION_BITS XLEN_C(1 << 7)
+#define RV_I_EXTENSION_BITS XLEN_C(1 << 8)
+#define RV_M_EXTENSION_BITS XLEN_C(1 << 12)
+#define RV_Q_EXTENSION_BITS XLEN_C(1 << 16)
+#define RV_S_IMPLEMENTED_BITS XLEN_C(1 << 18)
+#define RV_U_IMPLEMENTED_BITS XLEN_C(1 << 20)
+
+#define RV_32_MXLEN_BITS XLEN_C(0x40000000)
+#define RV_64_MXLEN_BITS XLEN_C(0x80000000)
+#define RV_128_MXLEN_BITS XLEN_C(0xC0000000)
+
+#define RV_32_XLEN_2_BITS 0b01
+
+#if XLEN == 32
+#define RV_ISA RV_32_MXLEN_BITS | RV_I_EXTENSION_BITS | RV_M_EXTENSION_BITS | RV_A_EXTENSION_BITS | RV_U_IMPLEMENTED_BITS | RV_S_IMPLEMENTED_BITS
+#else
+#define RV_ISA RV_64_MXLEN_BITS | RV_I_EXTENSION_BITS | RV_M_EXTENSION_BITS | RV_A_EXTENSION_BITS | RV_U_IMPLEMENTED_BITS | RV_S_IMPLEMENTED_BITS
+#endif
+
+#define RV_VENDOR_ID 0
+#define RV_ARCH_ID 0
+#define RV_IMPLEMENTATION_ID 0
+
+#define rv_csr_mstatus_tsr_mask (XLEN_C(1) << 22)
+#define rv_csr_mstatus_tw_mask (XLEN_C(1) << 21)
+#define rv_csr_mstatus_tvm_mask (XLEN_C(1) << 20)
+#define rv_csr_mstatus_mprv_mask (XLEN_C(1) << 17)
+#define rv_csr_mstatus_mpp_mask (XLEN_C(3) << 11)
+#define rv_csr_mstatus_mpie_mask (XLEN_C(1) << 7)
+#define rv_csr_mstatus_mie_mask (XLEN_C(1) << 3)
+
+// These are RV64 specific
+#define rv_csr_mstatus_mbe_mask (XLEN_C(1) << 37)
+#define rv_csr_mstatus_sbe_mask (XLEN_C(1) << 36)
+
+// These are RV32 specific
+#define rv_csr_mstatush_sbe_mask (UINT32_C(1) << 4)
+#define rv_csr_mstatush_mbe_mask (UINT32_C(1) << 5)
+
+#define rv_csr_mstatus_mpp_pos 11
+
+#define rv_csr_mstatus_tsr(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_tsr_mask)
+#define rv_csr_mstatus_tw(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_tw_mask)
+#define rv_csr_mstatus_tvm(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_tvm_mask)
+#define rv_csr_mstatus_mprv(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_mprv_mask)
+#define rv_csr_mstatus_mpie(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_mpie_mask)
+#define rv_csr_mstatus_mie(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_mie_mask)
+#define rv_csr_mstatus_mpp(cpu) (enum rv_priv_mode)(((cpu)->csr.mstatus & rv_csr_mstatus_mpp_mask) >> rv_csr_mstatus_mpp_pos)
+#define rv_csr_mstatus_mbe(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_mbe_mask)
+#define rv_csr_mstatus_sbe(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_mstatus_sbe_mask)
+
+#define rv_csr_sstatus_mxr_mask (XLEN_C(1) << 19)
+#define rv_csr_sstatus_sum_mask (XLEN_C(1) << 18)
+#define rv_csr_sstatus_spp_mask (XLEN_C(1) << 8)
+#define rv_csr_sstatus_ube_mask (XLEN_C(1) << 6)
+#define rv_csr_sstatus_spie_mask (XLEN_C(1) << 5)
+#define rv_csr_sstatus_sie_mask (XLEN_C(1) << 1)
+
+#define rv_csr_sstatus_spp_pos 8
+
+// Doesn't include UBE, because riscv in msim is strictly Little Endian
+// Also does not include SD, XS, FS abd VS, because these are used for extensions that are not implemented
+#define rv_csr_sstatus_mask (rv_csr_sstatus_mxr_mask | rv_csr_sstatus_sum_mask | rv_csr_sstatus_spp_mask | rv_csr_sstatus_spie_mask | rv_csr_sstatus_sie_mask)
+#define rv_csr_mstatus_mask (rv_csr_sstatus_mask | rv_csr_mstatus_tsr_mask | rv_csr_mstatus_tw_mask | rv_csr_mstatus_tvm_mask | rv_csr_mstatus_mprv_mask | rv_csr_mstatus_mpp_mask | rv_csr_mstatus_mpie_mask | rv_csr_mstatus_mie_mask)
+
+#define rv_csr_sstatus_mxr(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_sstatus_mxr_mask)
+#define rv_csr_sstatus_sum(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_sstatus_sum_mask)
+#define rv_csr_sstatus_spie(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_sstatus_spie_mask)
+#define rv_csr_sstatus_sie(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_sstatus_sie_mask)
+#define rv_csr_sstatus_spp(cpu) (enum rv_priv_mode)(((cpu)->csr.mstatus & rv_csr_sstatus_spp_mask) >> (rv_csr_sstatus_spp_pos))
+#define rv_csr_sstatus_ube(cpu) (bool) ((cpu)->csr.mstatus & rv_csr_sstatus_ube_mask)
+
+#define rv_csr_sei_mask (1U << 9)
+#define rv_csr_sti_mask (1U << 5)
+#define rv_csr_ssi_mask (1U << 1)
+#define rv_csr_mei_mask (1U << 11)
+#define rv_csr_mti_mask (1U << 7)
+#define rv_csr_msi_mask (1U << 3)
+#define rv_csr_si_mask (rv_csr_sei_mask | rv_csr_sti_mask | rv_csr_ssi_mask)
+#define rv_csr_mi_mask (rv_csr_si_mask | rv_csr_mei_mask | rv_csr_mti_mask | rv_csr_msi_mask)
+
+#define rv_csr_mtvec_mode_mask XLEN_C(0b11)
+#define rv_csr_mtvec_mode_direct XLEN_C(0)
+#define rv_csr_mtvec_mode_vectored XLEN_C(1)
+
+#if XLEN == 32
+
+#define rv_csr_satp_mode_mask 0x80000000
+#define rv_csr_asid_mask 0x7FC00000
+#define rv_csr_satp_ppn_mask 0x003FFFFF
+
+#define rv_csr_satp_asid_offset 22
+#define rv_csr_satp_asid(cpu) (((cpu)->csr.satp & rv_csr_asid_mask) >> 22)
+#define rv_asid_len 9
+
+#elif XLEN == 64
+
+#define rv_csr_satp_mode_mask (UINT64_C(8) << 60)
+#define rv_csr_asid_mask 0xFFFF00000000000
+#define rv_csr_satp_ppn_mask 0xFFFFFFFFFFF
+
+#define rv_csr_satp_asid_offset 44
+#define rv_csr_satp_asid(cpu) (((cpu)->csr.satp & rv_csr_asid_mask) >> rv_csr_satp_asid_offset)
+#define rv_asid_len 16
+
+#else
+
+#error "XLEN must be either 32 or 64"
+
+#endif
+
+#define rv_csr_satp_is_bare(cpu) (~(cpu)->csr.satp & rv_csr_satp_mode_mask)
+#define rv_csr_satp_ppn(cpu) ((cpu)->csr.satp & rv_csr_satp_ppn_mask)
+
+#define sv39_effective_priv(cpu) (rv_csr_mstatus_mprv(cpu) ? rv_csr_mstatus_mpp(cpu) : cpu->priv_mode)
+#define rv_effective_priv(cpu) (rv_csr_satp_is_bare(cpu) ? cpu->priv_mode : sv39_effective_priv(cpu))
+
+#define sv32_effective_priv(cpu) (rv_csr_mstatus_mprv(cpu) ? rv_csr_mstatus_mpp(cpu) : cpu->priv_mode)
+#define rv32_effective_priv(cpu) (rv_csr_satp_is_bare(cpu) ? cpu->priv_mode : sv32_effective_priv(cpu))
+
+#define rv_asid_mask ((1 << rv_asid_len) - 1)
+
+#define rv_csr_is_read_only(csr) (((csr) >> 30) == 0b11)
+
+#endif // RISCV_RV_CSR_H_

--- a/src/device/cpu/riscv_rv_ima/exception.h
+++ b/src/device/cpu/riscv_rv_ima/exception.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V Exception related constants
+ *
+ */
+
+#ifndef RISCV_RV_EXCEPTION_H_
+#define RISCV_RV_EXCEPTION_H_
+
+#include <stdint.h>
+
+#if XLEN == 32
+// MSb that determines if the exception is an interrupt
+#define RV_INTERRUPT_EXC_BITS UINT32_C(0x80000000)
+#define RV_EXCEPTION_EXC_BITS UINT32_C(0)
+#define RV_EXCEPTION_MASK(exc) (1U << ((exc) & ~RV_INTERRUPT_EXC_BITS))
+#define RV_INTERRUPT_NO(interrupt) ((interrupt) & ~RV_INTERRUPT_EXC_BITS)
+#else
+// MSb that determines if the exception is an interrupt
+#define RV_INTERRUPT_EXC_BITS UINT64_C(1UL << 63)
+#define RV_EXCEPTION_EXC_BITS UINT64_C(0)
+#define RV_EXCEPTION_MASK(exc) (UINT64_C(1) << ((exc) &0x3F))
+#define RV_INTERRUPT_NO(interrupt) ((interrupt) & ~RV_INTERRUPT_EXC_BITS)
+#endif
+
+/**
+ * RISC-V exception codes
+ *
+ * Includes Interrupt exception codes
+ */
+typedef enum rv_exc {
+    rv_exc_supervisor_software_interrupt = (RV_INTERRUPT_EXC_BITS) | 1,
+    rv_exc_machine_software_interrupt = (RV_INTERRUPT_EXC_BITS) | 3,
+    rv_exc_supervisor_timer_interrupt = (RV_INTERRUPT_EXC_BITS) | 5,
+    rv_exc_machine_timer_interrupt = RV_INTERRUPT_EXC_BITS | 7,
+    rv_exc_supervisor_external_interrupt = RV_INTERRUPT_EXC_BITS | 9,
+    rv_exc_machine_external_interrupt = RV_INTERRUPT_EXC_BITS | 11,
+    rv_exc_instruction_address_misaligned = RV_EXCEPTION_EXC_BITS | 0,
+    rv_exc_instruction_access_fault = RV_EXCEPTION_EXC_BITS | 1,
+    rv_exc_illegal_instruction = RV_EXCEPTION_EXC_BITS | 2,
+    rv_exc_breakpoint = RV_EXCEPTION_EXC_BITS | 3,
+    rv_exc_load_address_misaligned = RV_EXCEPTION_EXC_BITS | 4,
+    rv_exc_load_access_fault = RV_EXCEPTION_EXC_BITS | 5,
+    rv_exc_store_amo_address_misaligned = RV_EXCEPTION_EXC_BITS | 6,
+    rv_exc_store_amo_access_fault = RV_EXCEPTION_EXC_BITS | 7,
+    rv_exc_umode_environment_call = RV_EXCEPTION_EXC_BITS | 8,
+    rv_exc_smode_environment_call = RV_EXCEPTION_EXC_BITS | 9,
+    rv_exc_mmode_environment_call = RV_EXCEPTION_EXC_BITS | 11,
+    rv_exc_instruction_page_fault = RV_EXCEPTION_EXC_BITS | 12,
+    rv_exc_load_page_fault = RV_EXCEPTION_EXC_BITS | 13,
+    rv_exc_store_amo_page_fault = RV_EXCEPTION_EXC_BITS | 15,
+    rv_exc_none = RV_EXCEPTION_EXC_BITS | 24 /** Custom exception code, with the meaning that no exception has been raised */
+} rv_exc_t;
+
+/** Bitmask that has a bit set on every position that symbolizes an existing exception */
+#define RV_EXCEPTIONS_MASK ( \
+        RV_EXCEPTION_MASK(rv_exc_instruction_address_misaligned) | RV_EXCEPTION_MASK(rv_exc_instruction_access_fault) | RV_EXCEPTION_MASK(rv_exc_illegal_instruction) | RV_EXCEPTION_MASK(rv_exc_breakpoint) | RV_EXCEPTION_MASK(rv_exc_load_address_misaligned) | RV_EXCEPTION_MASK(rv_exc_load_access_fault) | RV_EXCEPTION_MASK(rv_exc_store_amo_address_misaligned) | RV_EXCEPTION_MASK(rv_exc_store_amo_access_fault) | RV_EXCEPTION_MASK(rv_exc_umode_environment_call) | RV_EXCEPTION_MASK(rv_exc_smode_environment_call) | RV_EXCEPTION_MASK(rv_exc_mmode_environment_call) | RV_EXCEPTION_MASK(rv_exc_instruction_page_fault) | RV_EXCEPTION_MASK(rv_exc_load_page_fault) | RV_EXCEPTION_MASK(rv_exc_store_amo_page_fault))
+/** Bitmask that has a bit set on every position that symbolizes an existing interrupt */
+#define RV_INTERRUPTS_MASK ( \
+        RV_EXCEPTION_MASK(rv_exc_supervisor_software_interrupt) | RV_EXCEPTION_MASK(rv_exc_machine_software_interrupt) | RV_EXCEPTION_MASK(rv_exc_supervisor_external_interrupt) | RV_EXCEPTION_MASK(rv_exc_machine_external_interrupt) | RV_EXCEPTION_MASK(rv_exc_supervisor_timer_interrupt) | RV_EXCEPTION_MASK(rv_exc_machine_timer_interrupt))
+
+/**
+ * Privilege modes
+ */
+typedef enum rv_priv_mode {
+    rv_umode = 0b00,
+    rv_smode = 0b01,
+    rv_rmode = 0b10, // RESERVED
+    rv_mmode = 0b11
+} rv_priv_mode_t;
+
+#endif

--- a/src/device/cpu/riscv_rv_ima/instr.h
+++ b/src/device/cpu/riscv_rv_ima/instr.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V Instructions
+ *
+ */
+
+#ifndef RISCV_RV_INSTR_H_
+#define RISCV_RV_INSTR_H_
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "../../../utils.h"
+#include "exception.h"
+#include "types.h"
+
+typedef union {
+    uint32_t val;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int rd : 5;
+        unsigned int funct3 : 3;
+        unsigned int rs1 : 5;
+        unsigned int rs2 : 5;
+        unsigned int funct7 : 7;
+    } r;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int rd : 5;
+        unsigned int funct3 : 3;
+        unsigned int rs1 : 5;
+        int imm : 12;
+    } i;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int imm4_0 : 5;
+        unsigned int funct3 : 3;
+        unsigned int rs1 : 5;
+        unsigned int rs2 : 5;
+        int imm11_5 : 7;
+    } s;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int imm11 : 1;
+        unsigned int imm4_1 : 4;
+        unsigned int funct3 : 3;
+        unsigned int rs1 : 5;
+        unsigned int rs2 : 5;
+        unsigned int imm10_5 : 6;
+        int imm12 : 1;
+    } b;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int rd : 5;
+        unsigned int imm : 20; // does not need to be sign extended
+    } u;
+    struct {
+        unsigned int opcode : 7;
+        unsigned int rd : 5;
+        unsigned int imm19_12 : 8;
+        unsigned int imm11 : 1;
+        unsigned int imm10_1 : 10;
+        int imm20 : 1;
+    } j;
+} rv_instr_t;
+
+static_assert(sizeof(rv_instr_t) == 4, "rv_instr_t has wrong size");
+
+#define RV_S_IMM(instr) (uxlen_t)((((xlen_t) instr.s.imm11_5) << 5) | ((0x1F) & instr.s.imm4_0))
+#define RV_R_FUNCT(instr) (uxlen_t)(((uxlen_t) (instr.r.funct7) << 3) | (0x7 & instr.r.funct3))
+#define RV_I_UNSIGNED_IMM(instr) (uxlen_t)(instr.i.imm & 0xFFF)
+#define RV_J_IMM(instr) (uxlen_t)((((xlen_t) instr.j.imm20) << 20) | (instr.j.imm19_12 << 12) | (instr.j.imm11 << 11) | (instr.j.imm10_1 << 1))
+#define RV_B_IMM(instr) (uxlen_t)((((xlen_t) instr.b.imm12) << 12) | (instr.b.imm11 << 11) | (instr.b.imm10_5 << 5) | (instr.b.imm4_1 << 1))
+#define RV_AMO_FUNCT(instr) (instr.r.funct7 >> 2)
+
+/** Opcodes*/
+typedef enum {
+    rv_opcLOAD = 0b0000011,
+    rv_opcLOAD_FP = 0b0000111, // not supported
+    rv_opcMISC_MEM = 0b0001111,
+    rv_opcOP_IMM = 0b0010011,
+    rv_opcAUIPC = 0b0010111,
+    rv_opcSTORE = 0b0100011,
+    rv_opcSTORE_FP = 0b0100111, // not supported
+    rv_opcAMO = 0b0101111,
+    rv_opcOP = 0b0110011,
+    rv_opcLUI = 0b0110111,
+    rv_opcOP_32 = 0b0111011,
+    rv_opcOP_IMM_32 = 0b0011011,
+    rv_opcMADD = 0b1000011, // not supported
+    rv_opcMSUB = 0b1000111, // not supported
+    rv_opcNMSUB = 0b1001011, // not supported
+    rv_opcNMADD = 0b1001111, // not supported
+    rv_opcOP_FP = 0b1010011, // not supported
+    rv_opcBRANCH = 0b1100011,
+    rv_opcJALR = 0b1100111,
+    rv_opcJAL = 0b1101111,
+    rv_opcSYSTEM = 0b1110011
+} rv_opcode_t;
+
+/** Funct values for OP instructions */
+typedef enum {
+    rv_func_ADD = 0b0000000000,
+    rv_func_SUB = 0b0100000000,
+    rv_func_SLL = 0b0000000001,
+    rv_func_SLT = 0b0000000010,
+    rv_func_SLTU = 0b0000000011,
+    rv_func_XOR = 0b0000000100,
+    rv_func_SRL = 0b0000000101,
+    rv_func_SRA = 0b0100000101,
+    rv_func_OR = 0b0000000110,
+    rv_func_AND = 0b0000000111,
+    /* M extension */
+    rv_func_MUL = 0b0000001000,
+    rv_func_MULH = 0b0000001001,
+    rv_func_MULHSU = 0b0000001010,
+    rv_func_MULHU = 0b0000001011,
+    rv_func_DIV = 0b0000001100,
+    rv_func_DIVU = 0b0000001101,
+    rv_func_REM = 0b0000001110,
+    rv_func_REMU = 0b0000001111
+} rv_op_func_t;
+
+/** Funct values for OP-imm instructions */
+typedef enum {
+    rv_func_ADDI = 0b000,
+    rv_func_SLTI = 0b010,
+    rv_func_SLTIU = 0b011,
+    rv_func_XORI = 0b100,
+    rv_func_ORI = 0b110,
+    rv_func_ANDI = 0b111,
+    rv_func_SLLI = 0b001,
+    rv_func_SRI = 0b101 // same for SRLI and SRAI
+} rv_op_imm_func_t;
+
+/** Values of the top 7 bits of imm field determining the right shift type */
+typedef enum {
+    rv_SRAI = 0b0100000,
+    rv_SRLI = 0b0000000,
+} rv_op_imm_right_shift_type_t;
+
+typedef enum {
+    rv64_SRAI = 0b0100000,
+    rv64_SRLI = 0b0000000,
+} rv64_op_imm_right_shift_type_t;
+
+/** Funct values for BRANCH instructions */
+typedef enum {
+    rv_func_BEQ = 0b000,
+    rv_func_BNE = 0b001,
+    rv_func_BLT = 0b100,
+    rv_func_BLTU = 0b110,
+    rv_func_BGE = 0b101,
+    rv_func_BGEU = 0b111
+} rv_branch_func_t;
+
+/** Funct values for LOAD instructions */
+typedef enum {
+    rv_func_LB = 0b000,
+    rv_func_LH = 0b001,
+    rv_func_LW = 0b010,
+    rv_func_LWU = 0b110,
+    rv_func_LD = 0b011,
+    rv_func_LBU = 0b100,
+    rv_func_LHU = 0b101
+} rv_load_func_t;
+
+/** Funct values for STORE instructions */
+typedef enum {
+    rv_func_SB = 0b000,
+    rv_func_SH = 0b001,
+    rv_func_SW = 0b010,
+    rv_func_SD = 0b011,
+} rv_store_func_t;
+
+/** Funct values for SYSTEM instructions */
+typedef enum {
+    rv_funcPRIV = 0b000,
+    rv_funcCSRRW = 0b001,
+    rv_funcCSRRS = 0b010,
+    rv_funcCSRRC = 0b011,
+    rv_funcCSRRWI = 0b101,
+    rv_funcCSRRSI = 0b110,
+    rv_funcCSRRCI = 0b111,
+
+} rv_system_func_t;
+
+/** Immediate values for PRIV SYSTEM instructions */
+typedef enum {
+    rv_privECALL = 0b000000000000,
+    rv_privEBREAK = 0b000000000001,
+    rv_privEHALT = 0b100011000000,
+    rv_privEDUMP = 0b100011000001,
+    rv_privETRACES = 0b100011000010,
+    rv_privETRACER = 0b100011000011,
+    rv_privECSRD = 0b100011000100,
+    rv_privSRET = 0b000100000010,
+    rv_privMRET = 0b001100000010,
+    rv_privWFI = 0b000100000101
+} rv_system_priv_imm_t;
+
+#define rv_privSFENCEVMA_FUNCT7 0b0001001
+
+/** Funct values for AMO instructions
+ *  This value is the high 5 bits from funct7
+ *  funct3 serves as the identifier of width of the instructions and only 32-bit width is supported now in msim
+ *  the low 2 bits from funct7 describe the ordering constraints (acquire/release semantics) - we can ignore them in msim, because we do in-order processing
+ */
+typedef enum {
+    rv_funcLR = 0b00010,
+    rv_funcSC = 0b00011,
+    rv_funcAMOSWAP = 0b00001,
+    rv_funcAMOADD = 0b00000,
+    rv_funcAMOXOR = 0b00100,
+    rv_funcAMOAND = 0b01100,
+    rv_funcAMOOR = 0b01000,
+    rv_funcAMOMIN = 0b10000,
+    rv_funcAMOMAX = 0b10100,
+    rv_funcAMOMINU = 0b11000,
+    rv_funcAMOMAXU = 0b11100
+} rv_amo_funct_t;
+
+#define RV_AMO_32_WLEN 0b010
+#define RV_AMO_64_WLEN 0b011
+
+typedef enum rv_exc (*rv_instr_func_t)(rv_cpu_t *, rv_instr_t);
+
+#endif // RISCV_RV_INSTR_H_

--- a/src/device/cpu/riscv_rv_ima/instructions/computations.c
+++ b/src/device/cpu/riscv_rv_ima/instructions/computations.c
@@ -1,0 +1,1147 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V arithmetic instructions
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include <stdint.h>
+
+#include "../../../../assert.h"
+#include "../../../../utils.h"
+#include "../exception.h"
+#include "../instr.h"
+
+rv_exc_t rv_read_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t *value, bool noisy);
+rv_exc_t rv_read_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t *value, bool fetch, bool noisy);
+rv_exc_t rv_write_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t value, bool noisy);
+rv_exc_t rv_write_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t value, bool noisy);
+rv_exc_t rv_write_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t value, bool noisy);
+rv_exc_t rv_write_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t value, bool noisy);
+rv_exc_t rv_convert_addr(rv_cpu_t *cpu, virt_t virt, ptr36_t *phys, bool wr, bool fetch, bool noisy);
+
+/******
+ * OP *
+ ******/
+
+static rv_exc_t rv_add_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs + rhs;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_addw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    int32_t rhs = (int32_t) cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs + rhs));
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sub_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs - rhs;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_subw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    int32_t rhs = (int32_t) cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs - rhs));
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sll_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    // based only on lowest 6 bits
+    uxlen_t rhs = shift_instr_mask(XLEN) & (cpu->regs[instr.r.rs2]);
+
+    cpu->regs[instr.r.rd] = lhs << rhs;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_sllw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    uint32_t lhs = (uint32_t) cpu->regs[instr.r.rs1];
+    // based only on lowest 5 bits
+    uint32_t rhs = 0x1F & (cpu->regs[instr.r.rs2]);
+
+    uint32_t result = lhs << rhs;
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) result);
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_slt_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = cpu->regs[instr.r.rs1];
+    xlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = (lhs < rhs) ? 1 : 0;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sltu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = (lhs < rhs) ? 1 : 0;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_xor_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs ^ rhs;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_srl_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    // based only on lowest 6 bits
+    uxlen_t rhs = shift_instr_mask(XLEN) & (cpu->regs[instr.r.rs2]);
+
+    cpu->regs[instr.r.rd] = lhs >> rhs;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_srlw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    uint32_t lhs = (uint32_t) cpu->regs[instr.r.rs1];
+    // based only on lowest 5 bits
+    uint32_t rhs = 0x1F & (cpu->regs[instr.r.rs2]);
+
+    uint32_t result = lhs >> rhs;
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) result);
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sra_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.r.rs1];
+    // based only on lowest 6 bits
+    uxlen_t rhs = shift_instr_mask(XLEN) & (cpu->regs[instr.r.rs2]);
+
+    cpu->regs[instr.r.rd] = (uxlen_t) (lhs >> rhs);
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_sraw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    // based only on lowest 5 bits
+    uint32_t rhs = 0x1F & (cpu->regs[instr.r.rs2]);
+
+    int32_t result = (lhs >> rhs);
+
+    cpu->regs[instr.r.rd] = (int64_t) result;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_or_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs | rhs;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_and_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs & rhs;
+
+    return rv_exc_none;
+}
+
+/**********
+ * OP-IMM *
+ **********/
+
+static rv_exc_t rv_addi_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    xlen_t imm;
+    if (XLEN == 32) {
+        imm = (int32_t) (instr.i.imm << 20) >> 20;
+    } else {
+        imm = (int64_t) ((int32_t) (instr.i.imm << 20) >> 20);
+    }
+
+    cpu->regs[instr.i.rd] = cpu->regs[instr.i.rs1] + imm;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_addiw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM_32);
+
+    int32_t imm = (int32_t) (instr.i.imm << 20) >> 20;
+
+    int32_t result = (int32_t) cpu->regs[instr.i.rs1] + imm;
+
+    cpu->regs[instr.i.rd] = (int64_t) result;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_slti_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    xlen_t imm = (xlen_t) ((int32_t) (instr.i.imm << 20) >> 20);
+
+    bool cmp = ((xlen_t) cpu->regs[instr.i.rs1] < imm);
+
+    cpu->regs[instr.i.rd] = cmp ? 1 : 0;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sltiu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    // sign extend to 64 bits, then change to unsigned
+    uxlen_t imm = (uxlen_t) ((xlen_t) ((int32_t) (instr.i.imm << 20) >> 20));
+
+    bool cmp = ((cpu->regs[instr.i.rs1]) < imm);
+
+    cpu->regs[instr.i.rd] = cmp ? 1 : 0;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_andi_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    xlen_t imm = (xlen_t) ((int32_t) (instr.i.imm << 20) >> 20);
+
+    uxlen_t val = cpu->regs[instr.i.rs1] & imm;
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_ori_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    xlen_t imm = (xlen_t) ((int32_t) (instr.i.imm << 20) >> 20);
+
+    uxlen_t val = cpu->regs[instr.i.rs1] | imm;
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_xori_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    xlen_t imm = (xlen_t) ((int32_t) (instr.i.imm << 20) >> 20);
+
+    uxlen_t val = cpu->regs[instr.i.rs1] ^ imm;
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+// TODO: figure this out
+static rv_exc_t rv_slli_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    uint32_t imm = instr.i.imm & 0x3F;
+
+    uint64_t val = cpu->regs[instr.i.rs1] << imm;
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_slliw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM_32);
+
+    uint32_t imm = instr.i.imm & 0x1F;
+
+    uint32_t val = (uint32_t) cpu->regs[instr.i.rs1] << imm;
+
+    cpu->regs[instr.i.rd] = (int64_t) ((int32_t) val);
+
+    return rv_exc_none;
+}
+
+// TODO: figure this out
+static rv_exc_t rv_srli_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    uint32_t imm = instr.i.imm & 0x3F;
+
+    uint64_t val = cpu->regs[instr.i.rs1] >> imm;
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_srliw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM_32);
+
+    uint32_t imm = instr.i.imm & 0x1F;
+
+    uint32_t val = (uint32_t) cpu->regs[instr.i.rs1] >> imm;
+
+    cpu->regs[instr.i.rd] = (int64_t) ((int32_t) val);
+
+    return rv_exc_none;
+}
+
+// TODO: figure this out
+static rv_exc_t rv_srai_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM);
+
+    uint32_t imm = instr.i.imm & 0x3F;
+
+    int64_t val = (int64_t) cpu->regs[instr.i.rs1] >> imm;
+
+    cpu->regs[instr.i.rd] = (uint64_t) val;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_sraiw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcOP_IMM_32);
+
+    uint32_t imm = instr.i.imm & 0x1F;
+
+    int32_t val = (int32_t) cpu->regs[instr.i.rs1] >> imm;
+
+    cpu->regs[instr.i.rd] = (int64_t) val;
+
+    return rv_exc_none;
+}
+
+/*****************
+ * LUI and AUIPC *
+ *****************/
+
+static rv_exc_t rv_lui_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.u.opcode == rv_opcLUI);
+
+    xlen_t imm_val = sign_extend_32_to_xlen(instr.u.imm << 12, XLEN);
+
+    cpu->regs[instr.u.rd] = imm_val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_auipc_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.u.opcode == rv_opcAUIPC);
+
+    xlen_t offset = sign_extend_32_to_xlen(instr.u.imm << 12, XLEN);
+
+    uxlen_t val = cpu->pc + offset;
+
+    cpu->regs[instr.u.rd] = val;
+
+    return rv_exc_none;
+}
+
+/***************
+ * M extension *
+ ***************/
+
+static rv_exc_t rv_mul_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    cpu->regs[instr.r.rd] = lhs * rhs;
+
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_mulw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    int32_t rhs = (int32_t) cpu->regs[instr.r.rs2];
+
+    int32_t result = lhs * rhs;
+
+    cpu->regs[instr.r.rd] = (int64_t) result;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_mulh_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.r.rs1];
+    xlen_t rhs = (xlen_t) cpu->regs[instr.r.rs2];
+
+    bigxlen_t res = (bigxlen_t) lhs * (bigxlen_t) rhs;
+
+    cpu->regs[instr.r.rd] = (uxlen_t) (res >> XLEN);
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_mulhsu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    bigxlen_t res = (bigxlen_t) lhs * (bigxlen_t) rhs;
+
+    cpu->regs[instr.r.rd] = (uxlen_t) (res >> XLEN);
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_mulhu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    ubigxlen_t res = (ubigxlen_t) lhs * (ubigxlen_t) rhs;
+
+    cpu->regs[instr.r.rd] = (uxlen_t) (res >> XLEN);
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_div_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.r.rs1];
+    xlen_t rhs = (xlen_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the result to -1
+        cpu->regs[instr.r.rd] = -1;
+        return rv_exc_none;
+    }
+
+    if (lhs == xlen_min(XLEN) && rhs == -1) {
+        // as per spec, divide overflow causes the result to be the minimal XLEN
+        cpu->regs[instr.r.rd] = xlen_min(XLEN);
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = lhs / rhs;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_divu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the result to the maximal val
+        cpu->regs[instr.r.rd] = uxlen_max(XLEN);
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = lhs / rhs;
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_divw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    // Truncate to 32 bits
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    int32_t rhs = (int32_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the result to -1
+        cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (-1));
+        return rv_exc_none;
+    }
+
+    if (lhs == INT32_MIN && rhs == -1) {
+        // as per spec, divide overflow causes the result to be the minimal int32
+        cpu->regs[instr.r.rd] = (int64_t) INT32_MIN;
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs / rhs));
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_divuw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    uint32_t lhs = (uint32_t) cpu->regs[instr.r.rs1];
+    uint32_t rhs = (uint32_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the result to the maximal val
+        cpu->regs[instr.r.rd] = (int64_t) ((int32_t) UINT32_MAX);
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs / rhs));
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_rem_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.r.rs1];
+    xlen_t rhs = (xlen_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the remained to the original value
+        cpu->regs[instr.r.rd] = lhs;
+        return rv_exc_none;
+    }
+
+    if (lhs == xlen_min(XLEN) && rhs == -1) {
+        // as per spec, divide overflow causes the remainder to be set to 0
+        cpu->regs[instr.r.rd] = 0;
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = lhs % rhs;
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_remw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    int32_t lhs = (int32_t) cpu->regs[instr.r.rs1];
+    int32_t rhs = (int32_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the remained to the original value
+        cpu->regs[instr.r.rd] = (int64_t) lhs;
+        return rv_exc_none;
+    }
+
+    if (lhs == INT32_MIN && rhs == -1) {
+        // as per spec, divide overflow causes the remainder to be set to 0
+        cpu->regs[instr.r.rd] = 0;
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs % rhs));
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_remu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP);
+
+    uxlen_t lhs = cpu->regs[instr.r.rs1];
+    uxlen_t rhs = cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the remainder to the original value
+        cpu->regs[instr.r.rd] = lhs;
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = lhs % rhs;
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_remuw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcOP_32);
+
+    uint32_t lhs = (uint32_t) cpu->regs[instr.r.rs1];
+    uint32_t rhs = (uint32_t) cpu->regs[instr.r.rs2];
+
+    if (rhs == 0) {
+        // as per spec, dividing by 0 sets the remainder to the original value
+        cpu->regs[instr.r.rd] = (int64_t) ((int32_t) lhs);
+        return rv_exc_none;
+    }
+
+    cpu->regs[instr.r.rd] = (int64_t) ((int32_t) (lhs % rhs));
+    return rv_exc_none;
+}
+
+/* A extension atomic operations */
+
+#define throw_ex(cpu, virt, ex) \
+    { \
+        cpu->csr.tval_next = virt; \
+        return ex; \
+    }
+
+#define throw_if_wrong_privilege(cpu, virt) \
+    { \
+        ptr36_t _; \
+        rv_exc_t ex; \
+        ex = rv_convert_addr(cpu, virt, &_, true, false, true); \
+        if (ex != rv_exc_none) { \
+            throw_ex(cpu, virt, ex); \
+        } \
+    }
+#define throw_if_misaligned_word(cpu, virt) \
+    { \
+        if (!IS_ALIGNED(virt, 4)) { \
+            throw_ex(cpu, virt, rv_exc_store_amo_address_misaligned); \
+        } \
+    }
+#define throw_if_misaligned_dword(cpu, virt) \
+    { \
+        if (!IS_ALIGNED(virt, 8)) { \
+            throw_ex(cpu, virt, rv_exc_store_amo_address_misaligned); \
+        } \
+    }
+
+static rv_exc_t rv_amoswap_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    // Check write privileges first
+    throw_if_wrong_privilege(cpu, virt);
+    // Then alignment
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    ex = rv_write_mem32(cpu, virt, (uint32_t) cpu->regs[instr.r.rs2], true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    return rv_exc_none;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amoswap_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    ex = rv_write_mem64(cpu, virt, cpu->regs[instr.r.rs2], true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_amoadd_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    // load from mem
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    // save loaded value to rd
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    // add with rs2
+    val += (uint32_t) cpu->regs[instr.r.rs2];
+
+    //  write to mem
+    ex = rv_write_mem32(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amoadd_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+    // load from mem
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    // save loaded value to rd
+    cpu->regs[instr.r.rd] = val;
+    // add with rs2
+    val += cpu->regs[instr.r.rs2];
+
+    //  write to mem
+    ex = rv_write_mem64(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+static rv_exc_t rv_amoxor_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    val ^= (uint32_t) cpu->regs[instr.r.rs2];
+    ex = rv_write_mem32(cpu, virt, val, true);
+
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amoxor_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    val ^= cpu->regs[instr.r.rs2];
+    ex = rv_write_mem64(cpu, virt, val, true);
+
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+static rv_exc_t rv_amoand_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    val &= (uint32_t) cpu->regs[instr.r.rs2];
+
+    ex = rv_write_mem32(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amoand_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+
+    val &= cpu->regs[instr.r.rs2];
+
+    ex = rv_write_mem64(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+
+    return ex;
+}
+
+static rv_exc_t rv_amoor_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    val |= (uint32_t) cpu->regs[instr.r.rs2];
+
+    ex = rv_write_mem32(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amoor_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+
+    val |= cpu->regs[instr.r.rs2];
+
+    ex = rv_write_mem64(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+
+    return ex;
+}
+
+static rv_exc_t rv_amomin_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    int32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, (uint32_t *) &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    int32_t rs2 = (int32_t) cpu->regs[instr.r.rs2];
+    val = rs2 < val ? rs2 : val;
+
+    ex = rv_write_mem32(cpu, virt, (uint32_t) val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amomin_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    int64_t val;
+    rv_exc_t ex = rv_read_mem64(cpu, virt, (uint64_t *) &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    int64_t rs2 = (int64_t) cpu->regs[instr.r.rs2];
+    val = rs2 < val ? rs2 : val;
+
+    ex = rv_write_mem64(cpu, virt, (uint64_t) val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+static rv_exc_t rv_amomax_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    int32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, (uint32_t *) &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = sign_extend_32_to_xlen(val, XLEN);
+    int32_t rs2 = (int32_t) cpu->regs[instr.r.rs2];
+    val = rs2 > val ? rs2 : val;
+
+    ex = rv_write_mem32(cpu, virt, (uint32_t) val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amomax_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    int64_t val;
+    rv_exc_t ex = rv_read_mem64(cpu, virt, (uint64_t *) &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    int64_t rs2 = (int64_t) cpu->regs[instr.r.rs2];
+    val = rs2 > val ? rs2 : val;
+
+    ex = rv_write_mem64(cpu, virt, (uint64_t) val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+static rv_exc_t rv_amominu_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = zero_extend_32_to_xlen(val, XLEN);
+    uint32_t rs2 = (uint32_t) cpu->regs[instr.r.rs2];
+    val = rs2 < val ? rs2 : val;
+
+    ex = rv_write_mem32(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amominu_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    uint64_t rs2 = cpu->regs[instr.r.rs2];
+    val = rs2 < val ? rs2 : val;
+
+    ex = rv_write_mem64(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+static rv_exc_t rv_amomaxu_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_word(cpu, virt);
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = zero_extend_32_to_xlen(val, XLEN);
+    uint32_t rs2 = (uint32_t) cpu->regs[instr.r.rs2];
+    val = rs2 > val ? rs2 : val;
+
+    ex = rv_write_mem32(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}
+
+/** RV64 ONLY */
+static rv_exc_t rv_amomaxu_d_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    throw_if_wrong_privilege(cpu, virt);
+    throw_if_misaligned_dword(cpu, virt);
+
+    uint64_t val;
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+    ASSERT(ex == rv_exc_none);
+
+    cpu->regs[instr.r.rd] = val;
+    uint64_t rs2 = cpu->regs[instr.r.rs2];
+    val = rs2 > val ? rs2 : val;
+
+    ex = rv_write_mem64(cpu, virt, val, true);
+    ASSERT(ex == rv_exc_none);
+    return ex;
+}

--- a/src/device/cpu/riscv_rv_ima/instructions/control_transfer.c
+++ b/src/device/cpu/riscv_rv_ima/instructions/control_transfer.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V Jump and branch instructions
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include <stdint.h>
+
+#include "../../../../assert.h"
+#include "../../../../utils.h"
+#include "../exception.h"
+#include "../instr.h"
+#include "../types.h"
+
+rv_exc_t rv_read_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t *value, bool noisy);
+rv_exc_t rv_read_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t *value, bool fetch, bool noisy);
+rv_exc_t rv_write_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t value, bool noisy);
+rv_exc_t rv_write_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t value, bool noisy);
+rv_exc_t rv_write_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t value, bool noisy);
+rv_exc_t rv_write_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t value, bool noisy);
+rv_exc_t rv_convert_addr(rv_cpu_t *cpu, virt_t virt, ptr36_t *phys, bool wr, bool fetch, bool noisy);
+
+static rv_exc_t rv_jal_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.j.opcode == rv_opcJAL);
+
+    // jump target is relative to the address of the instruction eg. pc
+    uxlen_t target = cpu->pc + RV_J_IMM(instr);
+
+    if (!IS_ALIGNED(target, 4)) {
+        cpu->csr.tval_next = target;
+        return rv_exc_instruction_address_misaligned;
+    }
+
+    cpu->regs[instr.j.rd] = cpu->pc + 4;
+
+    cpu->pc_next = target;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_jalr_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcJALR);
+    ASSERT(instr.i.funct3 == 0);
+
+    uxlen_t target = cpu->regs[instr.i.rs1] + instr.i.imm;
+    // lowest bit set to 0, as described in the specification
+    target &= ~1;
+
+    if (!IS_ALIGNED(target, 4)) {
+        cpu->csr.tval_next = target;
+        return rv_exc_instruction_address_misaligned;
+    }
+
+    cpu->regs[instr.j.rd] = cpu->pc + 4;
+
+    cpu->pc_next = target;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_beq_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    uxlen_t lhs = cpu->regs[instr.b.rs1];
+    uxlen_t rhs = cpu->regs[instr.b.rs2];
+
+    if (lhs == rhs) {
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_bne_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    uxlen_t lhs = cpu->regs[instr.b.rs1];
+    uxlen_t rhs = cpu->regs[instr.b.rs2];
+
+    if (lhs != rhs) {
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_blt_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.b.rs1];
+    xlen_t rhs = (xlen_t) cpu->regs[instr.b.rs2];
+
+    if (lhs < rhs) {
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_bltu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    uxlen_t lhs = cpu->regs[instr.b.rs1];
+    uxlen_t rhs = cpu->regs[instr.b.rs2];
+
+    if (lhs < rhs) {
+
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_bge_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    xlen_t lhs = (xlen_t) cpu->regs[instr.b.rs1];
+    xlen_t rhs = (xlen_t) cpu->regs[instr.b.rs2];
+
+    if (lhs >= rhs) {
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_bgeu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.b.opcode == rv_opcBRANCH);
+
+    // target is relative to address of the instruction
+    uxlen_t target = cpu->pc + RV_B_IMM(instr);
+
+    uxlen_t lhs = cpu->regs[instr.b.rs1];
+    uxlen_t rhs = cpu->regs[instr.b.rs2];
+
+    if (lhs >= rhs) {
+        if (!IS_ALIGNED(target, 4)) {
+            cpu->csr.tval_next = target;
+            return rv_exc_instruction_address_misaligned;
+        }
+        cpu->pc_next = target;
+    }
+
+    return rv_exc_none;
+}

--- a/src/device/cpu/riscv_rv_ima/instructions/mem_ops.c
+++ b/src/device/cpu/riscv_rv_ima/instructions/mem_ops.c
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ * RISC-V Instructions that provide memory access
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include <stdint.h>
+
+#include "../../../../assert.h"
+#include "../../../../fault.h"
+#include "../../../../physmem.h"
+#include "../../../../utils.h"
+#include "../csr.h"
+#include "../exception.h"
+#include "../instr.h"
+
+rv_exc_t rv_read_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t *value, bool noisy);
+rv_exc_t rv_read_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t *value, bool fetch, bool noisy);
+rv_exc_t rv_write_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t value, bool noisy);
+rv_exc_t rv_write_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t value, bool noisy);
+rv_exc_t rv_write_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t value, bool noisy);
+rv_exc_t rv_write_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t value, bool noisy);
+rv_exc_t rv_convert_addr(rv_cpu_t *cpu, virt_t virt, ptr36_t *phys, bool wr, bool fetch, bool noisy);
+
+static ALWAYS_INLINE rv_read_xlen_t rv_read_xlen()
+{
+    // Invariant: These casts are safe since XLEN is always set, and thus is uxlen_t
+    if (XLEN == 32) {
+        return (rv_read_xlen_t) rv_read_mem32;
+    } else if (XLEN == 64) {
+        return (rv_read_xlen_t) rv_read_mem64;
+    } else {
+        return (rv_read_xlen_t) rv_read_mem64;
+    }
+}
+
+enum rv_exc rv_csr_rw(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool read);
+enum rv_exc rv_csr_rs(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool write);
+enum rv_exc rv_csr_rc(rv_cpu_t *cpu, csr_num_t csr, uxlen_t value, uxlen_t *read_target, bool write);
+
+static rv_exc_t rv_lb_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    uint8_t val;
+
+    rv_exc_t ex = rv_read_mem8(cpu, virt, &val, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    // Sign extension magic
+    cpu->regs[instr.i.rd] = sign_extend_8_to_xlen(val, XLEN);
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_lh_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    uint16_t val;
+
+    rv_exc_t ex = rv_read_mem16(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    // Sign extension magic
+    cpu->regs[instr.i.rd] = sign_extend_16_to_xlen(val, XLEN);
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_lw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    if (!IS_ALIGNED(virt, 4)) {
+        cpu->csr.tval_next = virt;
+        return rv_exc_load_address_misaligned;
+    }
+
+    uint32_t val;
+
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    cpu->regs[instr.i.rd] = sign_extend_32_to_xlen(val, XLEN);
+
+    return rv_exc_none;
+}
+
+/** RV64 SPECIFIC */
+static rv_exc_t rv_ld_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    // ! Maybe???
+    if (!IS_ALIGNED(virt, 8)) {
+        cpu->csr.tval_next = virt;
+        return rv_exc_load_address_misaligned;
+    }
+
+    uint64_t val;
+
+    rv_exc_t ex = rv_read_mem64(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    cpu->regs[instr.i.rd] = val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_lbu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    uint8_t val;
+
+    rv_exc_t ex = rv_read_mem8(cpu, virt, &val, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    cpu->regs[instr.i.rd] = (uxlen_t) val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_lhu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    if (!IS_ALIGNED(virt, 2)) {
+        cpu->csr.tval_next = virt;
+        return rv_exc_load_address_misaligned;
+    }
+
+    uint16_t val;
+
+    rv_exc_t ex = rv_read_mem16(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    cpu->regs[instr.i.rd] = (uxlen_t) val;
+
+    return rv_exc_none;
+}
+
+/** RV64 SPECIFIC */
+static rv_exc_t rv_lwu_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcLOAD);
+
+    uxlen_t virt = cpu->regs[instr.i.rs1] + (xlen_t) instr.i.imm;
+
+    if (!IS_ALIGNED(virt, 4)) {
+        cpu->csr.tval_next = virt;
+        return rv_exc_load_address_misaligned;
+    }
+
+    uint32_t val;
+
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        return ex;
+    }
+
+    cpu->regs[instr.i.rd] = (uxlen_t) val;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sb_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.s.opcode == rv_opcSTORE);
+
+    uxlen_t virt = cpu->regs[instr.s.rs1] + RV_S_IMM(instr);
+
+    return rv_write_mem8(cpu, virt, (uint8_t) cpu->regs[instr.s.rs2], true);
+}
+
+static rv_exc_t rv_sh_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.s.opcode == rv_opcSTORE);
+
+    uxlen_t virt = cpu->regs[instr.s.rs1] + RV_S_IMM(instr);
+
+    return rv_write_mem16(cpu, virt, (uint16_t) cpu->regs[instr.s.rs2], true);
+}
+
+static rv_exc_t rv_sw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.s.opcode == rv_opcSTORE);
+
+    uxlen_t virt = cpu->regs[instr.s.rs1] + RV_S_IMM(instr);
+
+    return rv_write_mem32(cpu, virt, (uint32_t) cpu->regs[instr.s.rs2], true);
+}
+
+/** RV64 SPECIFIC */
+static rv_exc_t rv_sd_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.s.opcode == rv_opcSTORE);
+
+    uxlen_t virt = cpu->regs[instr.s.rs1] + RV_S_IMM(instr);
+
+    return rv_write_mem64(cpu, virt, cpu->regs[instr.s.rs2], true);
+}
+
+static rv_exc_t rv_fence_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    // FENCE instruction does nothing in deterministic emulator,
+    // where out-of-order processing is not allowed
+    return rv_exc_none;
+}
+
+/* A extension LR and SC */
+
+static rv_exc_t rv_lr_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+    ASSERT(instr.r.rs2 == 0);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    uint32_t val;
+    rv_exc_t ex = rv_read_mem32(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        // if read failed, cancel all previous reservations
+        sc_unregister(cpu->csr.mhartid);
+        cpu->reserved_valid = false;
+        return ex;
+    }
+
+    // The missalignment should be caught in rv_read_mem32
+    // Bit if we would choose to allow missaligned accesses in the future,
+    // this would break, so this is here just for safety
+    if (!IS_ALIGNED(virt, 4)) {
+        sc_unregister(cpu->csr.mhartid);
+        cpu->reserved_valid = false;
+        return rv_exc_load_address_misaligned;
+    }
+
+    // store the read value
+    cpu->regs[instr.r.rd] = zero_extend_32_to_xlen(val, XLEN);
+
+    // we track physical addresses, so convert
+    // this should not fail
+
+    ptr36_t phys;
+    ex = rv_convert_addr(cpu, virt, &phys, false, false, false);
+    ASSERT(ex == rv_exc_none);
+
+    // register address for tracking
+
+    sc_register(cpu->csr.mhartid);
+    cpu->reserved_valid = true;
+    cpu->reserved_addr = phys;
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_sc_w_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    // convert addr and check if the target is tracked
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+    ptr36_t phys;
+
+    if (cpu->reserved_valid == false) {
+        // reservation is not valid
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_none;
+    }
+
+    // SC always invalidates reservation by this hart
+    cpu->reserved_valid = false;
+    sc_unregister(cpu->csr.mhartid);
+
+    rv_exc_t ex = rv_convert_addr(cpu, virt, &phys, true, false, true);
+
+    if (ex != rv_exc_none) {
+        cpu->regs[instr.r.rd] = 1;
+        return ex;
+    }
+
+    if (!IS_ALIGNED(virt, 4)) {
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_store_amo_address_misaligned;
+    }
+
+    if (phys != cpu->reserved_addr) {
+        alert("RV32IMA: LR/SC addresses do not match");
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_none;
+    }
+
+    // phys == reserved_addr
+    // here we suppose that only 32-bit reservations to aligned addresses are possible
+    // but since mips does not allow unaligned accesses, and only 32-bit ll is now supported in msim for mips
+    // and risc-v allows only aligned accesses (without Zam extension) and only 32-bit atomics are supported here
+    // this should be fine
+
+    ex = rv_write_mem32(cpu, virt, (uint32_t) cpu->regs[instr.r.rs2], true);
+
+    if (ex != rv_exc_none) {
+        alert("RV32IMA: SC write failed after successful address translation");
+        cpu->regs[instr.r.rd] = 1;
+        return ex;
+    }
+
+    cpu->regs[instr.r.rd] = 0;
+    return rv_exc_none;
+}
+
+/**
+ * Load-Reserved instruction implementation for RV64
+ *
+ * Loads a XLEN-bit value from memory at address in rs1 and registers the address
+ * for a subsequent store-conditional. Places the loaded value in rd.
+ */
+static rv_exc_t rv_lr_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+    ASSERT(instr.r.rs2 == 0);
+
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+
+    uxlen_t val;
+    rv_exc_t ex = rv_read_xlen()(cpu, virt, &val, false, true);
+
+    if (ex != rv_exc_none) {
+        // if read failed, cancel all previous reservations
+        sc_unregister(cpu->csr.mhartid);
+        cpu->reserved_valid = false;
+        return ex;
+    }
+
+    if (!IS_ALIGNED(virt, alignment_by_XLEN)) {
+        sc_unregister(cpu->csr.mhartid);
+        cpu->reserved_valid = false;
+        return rv_exc_load_address_misaligned;
+    }
+
+    // store the read value
+    cpu->regs[instr.r.rd] = val;
+
+    ptr36_t phys;
+    ex = rv_convert_addr(cpu, virt, &phys, false, false, false);
+    ASSERT(ex == rv_exc_none);
+
+    sc_register(cpu->csr.mhartid);
+    cpu->reserved_valid = true;
+    cpu->reserved_addr = phys;
+
+    return rv_exc_none;
+}
+
+/**
+ * Store-Conditional instruction implementation for RV64
+ *
+ * Stores a XLEN-bit value from rs2 to memory at address in rs1 if a valid
+ * reservation exists. Returns 0 in rd on success, 1 on failure.
+ */
+static rv_exc_t rv_sc_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.r.opcode == rv_opcAMO);
+
+    // Get virtual address from rs1
+    uxlen_t virt = cpu->regs[instr.r.rs1];
+    ptr36_t phys;
+
+    if (cpu->reserved_valid == false) {
+        // reservation is not valid, return failure
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_none;
+    }
+
+    // SC always invalidates reservation by this hart
+    cpu->reserved_valid = false;
+    sc_unregister(cpu->csr.mhartid);
+
+    rv_exc_t ex = rv_convert_addr(cpu, virt, &phys, true, false, true);
+
+    if (ex != rv_exc_none) {
+        cpu->regs[instr.r.rd] = 1;
+        return ex;
+    }
+
+    // Check alignment - doubleword must be aligned to 8 bytes in RV64
+    if (!IS_ALIGNED(virt, 8)) {
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_store_amo_address_misaligned;
+    }
+
+    // Check if this is the same address that was reserved
+    if (phys != cpu->reserved_addr) {
+        alert("RV64IMA: LR/SC addresses do not match");
+        cpu->regs[instr.r.rd] = 1;
+        return rv_exc_none;
+    }
+
+    ex = rv_write_mem64(cpu, virt, cpu->regs[instr.r.rs2], true);
+
+    if (ex != rv_exc_none) {
+        alert("RV64IMA: SC write failed after successful address translation");
+        cpu->regs[instr.r.rd] = 1;
+        return ex;
+    }
+
+    // Success: store 0 to rd
+    cpu->regs[instr.r.rd] = 0;
+    return rv_exc_none;
+}

--- a/src/device/cpu/riscv_rv_ima/instructions/system.c
+++ b/src/device/cpu/riscv_rv_ima/instructions/system.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2022 Jan Papesch
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ * RISC-V System instructions
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include <stdint.h>
+
+#include "../../../../assert.h"
+#include "../../../../fault.h"
+#include "../../../../input.h"
+#include "../csr.h"
+#include "../exception.h"
+#include "../instr.h"
+
+rv_exc_t rv_read_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t *value, bool noisy);
+rv_exc_t rv_read_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t *value, bool fetch, bool noisy);
+rv_exc_t rv_read_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t *value, bool fetch, bool noisy);
+rv_exc_t rv_write_mem8(rv_cpu_t *cpu, virt_t virt, uint8_t value, bool noisy);
+rv_exc_t rv_write_mem16(rv_cpu_t *cpu, virt_t virt, uint16_t value, bool noisy);
+rv_exc_t rv_write_mem32(rv_cpu_t *cpu, virt_t virt, uint32_t value, bool noisy);
+rv_exc_t rv_write_mem64(rv_cpu_t *cpu, virt_t virt, uint64_t value, bool noisy);
+rv_exc_t rv_convert_addr(rv_cpu_t *cpu, virt_t virt, ptr36_t *phys, bool wr, bool fetch, bool noisy);
+
+static rv_exc_t rv_break_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcSYSTEM);
+
+    if (input_is_terminal() || machine_allow_interactive_without_tty) {
+        alert("EBREAK: breakpoint reached, entering interactive mode");
+        machine_interactive = true;
+    } else {
+        alert("EBREAK: Machine halt when no tty available.");
+        machine_halt = true;
+    }
+
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_halt_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcSYSTEM);
+
+    alert("EHALT: Machine halt");
+
+    machine_halt = true;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_trace_set_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcSYSTEM);
+    alert("ETRACES: Trace Set");
+    machine_trace = true;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_trace_reset_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    ASSERT(cpu != NULL);
+    ASSERT(instr.i.opcode == rv_opcSYSTEM);
+    alert("ETRACES: Trace Reset");
+    machine_trace = false;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_call_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    switch (cpu->priv_mode) {
+    case rv_umode:
+        return rv_exc_umode_environment_call;
+    case rv_smode:
+        return rv_exc_smode_environment_call;
+    case rv_mmode:
+        return rv_exc_mmode_environment_call;
+    default:
+        return rv_exc_illegal_instruction;
+    }
+}
+
+static rv_exc_t rv_sret_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    if (rv_csr_mstatus_tsr(cpu)) {
+        return rv_exc_illegal_instruction;
+    }
+    if (cpu->priv_mode < rv_smode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    rv_priv_mode_t spp_priv = rv_csr_sstatus_spp(cpu);
+
+    // SIE = SPIE
+    {
+        if (rv_csr_sstatus_spie(cpu)) {
+            cpu->csr.mstatus |= rv_csr_sstatus_sie_mask;
+        } else {
+            cpu->csr.mstatus &= ~rv_csr_sstatus_sie_mask;
+        }
+    }
+    // priv = SPP
+    {
+        cpu->priv_mode = spp_priv;
+    }
+    // SPIE = 1
+    {
+        cpu->csr.mstatus |= rv_csr_sstatus_spie_mask;
+    }
+    // SPP = U
+    {
+        cpu->csr.mstatus &= ~rv_csr_sstatus_spp_mask;
+        // SPP = 00 (can be skipped, sice U mode is 0)
+    }
+    // if SPP != M: MPRV = 0
+    {
+        // This must always happen, because sret can return only to U or S mode
+        cpu->csr.mstatus &= ~rv_csr_mstatus_mprv_mask;
+    }
+
+    cpu->pc_next = cpu->csr.sepc;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_mret_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    if (cpu->priv_mode < rv_mmode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    rv_priv_mode_t mpp_priv = rv_csr_mstatus_mpp(cpu);
+
+    // MIE = MPIE
+    {
+        if (rv_csr_mstatus_mpie(cpu)) {
+            cpu->csr.mstatus |= rv_csr_mstatus_mie_mask;
+        } else {
+            cpu->csr.mstatus &= ~rv_csr_mstatus_mie_mask;
+        }
+    }
+    // priv = MPP
+    {
+        cpu->priv_mode = mpp_priv;
+    }
+    // MPIE = 1
+    {
+        cpu->csr.mstatus |= rv_csr_mstatus_mpie_mask;
+    }
+    // MPP = U
+    {
+        cpu->csr.mstatus &= ~rv_csr_mstatus_mpp_mask;
+        // MPP = 00 (can be skipped, sice U mode is 00)
+    }
+    // if MPP != M: MPRV = 0
+    {
+        if (mpp_priv != rv_mmode) {
+            cpu->csr.mstatus &= ~rv_csr_mstatus_mprv_mask;
+        }
+    }
+
+    cpu->pc_next = cpu->csr.mepc;
+    return rv_exc_none;
+}
+
+static rv_exc_t rv_wfi_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+
+    if (rv_csr_mstatus_tw(cpu) && cpu->priv_mode != rv_mmode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    if (cpu->priv_mode == rv_umode) {
+        return rv_exc_illegal_instruction;
+    }
+
+    cpu->stdby = true;
+    return rv_exc_none;
+}
+
+// Note: csrrw reads with rd = x0 shall not read the CSR and shall not have any side-efects based on the read
+//       similarly, csrrs and csrrc writes with rs1 = x0 (or uimm = 0) shall not write anything
+
+static rv_exc_t rv_csrrw_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = cpu->regs[instr.i.rs1];
+    uxlen_t *rd = (uxlen_t *) (&cpu->regs[instr.i.rd]);
+    bool read = instr.i.rd != 0;
+
+    return rv_csr_rw((void *) cpu, csr, val, rd, read);
+}
+
+static rv_exc_t rv_csrrs_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = cpu->regs[instr.i.rs1];
+    uxlen_t *rd = (uxlen_t *) &cpu->regs[instr.i.rd];
+    bool write = instr.i.rs1 != 0;
+
+    return rv_csr_rs((void *) cpu, csr, val, rd, write);
+}
+
+static rv_exc_t rv_csrrc_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = cpu->regs[instr.i.rs1];
+    uxlen_t *rd = (uxlen_t *) &cpu->regs[instr.i.rd];
+    bool write = instr.i.rs1 != 0;
+
+    return rv_csr_rc((void *) cpu, csr, val, rd, write);
+}
+
+static rv_exc_t rv_csrrwi_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = instr.i.rs1; // Zero extended
+    uxlen_t *rd = (uxlen_t *) &cpu->regs[instr.i.rd];
+    bool read = instr.i.rd != 0;
+
+    return rv_csr_rw((void *) cpu, csr, val, rd, read);
+}
+
+static rv_exc_t rv_csrrsi_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = instr.i.rs1; // Zero extended
+    uxlen_t *rd = (uxlen_t *) &cpu->regs[instr.i.rd];
+    bool write = instr.i.rs1 != 0;
+
+    return rv_csr_rs((void *) cpu, csr, val, rd, write);
+}
+
+static rv_exc_t rv_csrrci_instr(rv_cpu_t *cpu, rv_instr_t instr)
+{
+    int csr = ((uint32_t) instr.i.imm) & 0xFFF;
+    uxlen_t val = instr.i.rs1; // Zero extended
+    uxlen_t *rd = (uxlen_t *) &cpu->regs[instr.i.rd];
+    bool write = instr.i.rs1 != 0;
+
+    return rv_csr_rc((void *) cpu, csr, val, rd, write);
+}

--- a/src/device/cpu/riscv_rv_ima/types.h
+++ b/src/device/cpu/riscv_rv_ima/types.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2025 Martin Rosenberg
+ * All rights reserved.
+ *
+ * Distributed under the terms of GPL.
+ *
+ *
+ *  RISC-V Generic types
+ *
+ */
+
+#pragma GCC diagnostic ignored "-Woverflow"
+
+#ifndef RISCV_RV_COMMON_TYPES_H_
+#define RISCV_RV_COMMON_TYPES_H_
+
+#include <stdint.h>
+
+#include "exception.h"
+
+#ifndef ALWAYS_INLINE
+#define ALWAYS_INLINE inline __attribute__((always_inline))
+#endif
+
+#if XLEN == 64
+typedef uint64_t uxlen_t;
+typedef uint64_t virt_t;
+typedef int64_t xlen_t;
+typedef __int128 bigxlen_t;
+typedef unsigned __int128 ubigxlen_t;
+#elif XLEN == 32
+typedef uint32_t uxlen_t;
+typedef uint32_t virt_t;
+typedef int32_t xlen_t;
+typedef int64_t bigxlen_t;
+typedef uint64_t ubigxlen_t;
+#else
+#error "XLEN is not set to 32 or 64 bits"
+#endif
+
+#if XLEN == 64
+struct rv64_cpu;
+typedef struct rv64_cpu rv_cpu_t;
+#else
+struct rv32_cpu;
+typedef struct rv32_cpu rv_cpu_t;
+#endif
+
+static ALWAYS_INLINE xlen_t sign_extend_8_to_xlen(uint8_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 8 bit value to 32 bits (xlen_t = int32_t)
+        return (int32_t) ((int16_t) ((int8_t) value));
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (int64_t) ((int32_t) ((int16_t) ((int8_t) value)));
+    } else {
+        return (int64_t) ((int32_t) ((int16_t) ((int8_t) value)));
+    }
+}
+
+static ALWAYS_INLINE xlen_t sign_extend_16_to_xlen(uint16_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 16 bit value to 32 bits (xlen_t = int32_t)
+        return (int32_t) ((int16_t) value);
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (int64_t) ((int32_t) ((int16_t) value));
+    } else {
+        return (int64_t) ((int32_t) ((int16_t) value));
+    }
+}
+
+static ALWAYS_INLINE xlen_t sign_extend_32_to_xlen(uint32_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 32 bit value to 32 bits (xlen_t = int32_t)
+        return (int32_t) value;
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (int64_t) ((int32_t) value);
+    } else {
+        return (int64_t) ((int32_t) value);
+    }
+}
+
+static ALWAYS_INLINE xlen_t sign_extend_64_to_xlen(uint64_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 64 bit value to 32 bits (xlen_t = int32_t) = TRUNCATION
+        return (int32_t) value;
+    } else if (xlen == 64) {
+        // Sign extend 64 bit value to 64 bits (xlen_t = int64_t) = just a cast
+        return (int64_t) value;
+    } else {
+        return (int64_t) value;
+    }
+}
+
+/** ZERO extension */
+
+static ALWAYS_INLINE uxlen_t zero_extend_8_to_xlen(uint8_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 8 bit value to 32 bits (xlen_t = int32_t)
+        return (uint32_t) ((uint16_t) ((uint8_t) value));
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (uint64_t) ((uint32_t) ((uint16_t) ((uint8_t) value)));
+    } else {
+        return (uint64_t) ((uint32_t) ((uint16_t) ((uint8_t) value)));
+    }
+}
+
+static ALWAYS_INLINE uxlen_t zero_extend_16_to_xlen(uint16_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 16 bit value to 32 bits (xlen_t = int32_t)
+        return (uint32_t) ((uint16_t) value);
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (uint64_t) ((uint32_t) ((uint16_t) value));
+    } else {
+        return (uint64_t) ((uint32_t) ((uint16_t) value));
+    }
+}
+
+static ALWAYS_INLINE xlen_t zero_extend_32_to_xlen(uint32_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 32 bit value to 32 bits (xlen_t = int32_t)
+        return (uint32_t) value;
+    } else if (xlen == 64) {
+        // Sign extend 8 bit value to 64 bits (xlen_t = int64_t)
+        return (uint64_t) ((uint32_t) value);
+    } else {
+        return (uint64_t) ((uint32_t) value);
+    }
+}
+
+static ALWAYS_INLINE uxlen_t zero_extend_64_to_xlen(uint64_t const value, int const xlen)
+{
+    if (xlen == 32) {
+        // Sign extend 64 bit value to 32 bits (xlen_t = int32_t) = TRUNCATION
+        return (uint32_t) value;
+    } else if (xlen == 64) {
+        // Sign extend 64 bit value to 64 bits (xlen_t = int64_t) = just a cast
+        return (uint64_t) value;
+    } else {
+        return (uint64_t) value;
+    }
+}
+
+#if XLEN == 64
+#define XLEN_C UINT64_C
+#else
+#define XLEN_C UINT32_C
+#endif
+
+/** Address alignment constants */
+
+#define alignment_by_XLEN (XLEN == 32 ? 4 : (XLEN == 64 ? 8 : 8))
+
+/** Read and write operation aliases by XLEN */
+
+typedef rv_exc_t (*rv_read_xlen_t)(rv_cpu_t *, virt_t, uxlen_t *, bool, bool);
+
+/** Instruction constants */
+
+static ALWAYS_INLINE int shift_instr_mask(int const xlen)
+{
+    if (xlen == 32) {
+        return 0x1F;
+    } else if (xlen == 64) {
+        return 0x3F;
+    } else {
+        return 0x3F;
+    }
+}
+
+static ALWAYS_INLINE xlen_t xlen_min(int const xlen)
+{
+    if (xlen == 32) {
+        return INT32_MIN;
+    } else if (xlen == 64) {
+        return INT64_MIN;
+    } else {
+        return INT64_MIN;
+    }
+}
+
+static ALWAYS_INLINE xlen_t uxlen_max(int const xlen)
+{
+    if (xlen == 32) {
+        return UINT32_MAX;
+    } else if (xlen == 64) {
+        return UINT64_MAX;
+    } else {
+        return UINT64_MAX;
+    }
+}
+
+#endif // RISCV_RV_COMMON_TYPES_H_


### PR DESCRIPTION
This pull request adds a generic implementation of the RV32/RV64 IMA with the goal to have 64-bit RISC-V CPU support in MSIM. The selection is dictated by defining the `XLEN` variable with a `#define` block. Added files include:

- Types, macros and functions which are `XLEN`-dependent,
- Structures and enums used for instruction decoding (instruction format is the same on both architectures)
- CSR-related code
- Instruction code, which can be shared by both architectures. In some cases, the specification defines two variants (see the `AMOxxx` instructions, which appear with the `_w` and `_d` suffix). 

This is not included in the generic IMA:

- Instruction decoding (which is architecture dependent and thus makes more sense to implement separately)
- TLB and virtual memory management (Sv32 versus Sv39)

What could be made generic in the future (maybe?):

- Debug and mnemonics code (the `mnemonics.c` is large and could possibly be made shared by both architectures)

More progress will hopefully be merged. Until then, the next steps are:

1. Merge this
2. Merge converting the existing RV32 IMA implementation to use the generic one ([here](https://github.com/rosenbergm/msim/tree/convert-rv32-to-rv-generic))
3. Merge adding the RV64 IMA ([here](https://github.com/rosenbergm/msim/tree/add-rv64))