### PR TITLE
Fix inconsistent readline prompt behavior across platforms

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -94,6 +94,7 @@ static char **msim_completion(const char *text, int start, int end)
  */
 void input_init(void)
 {
+    using_history();
     input_term = !!isatty(0);
 
     if (!input_term) {
@@ -118,7 +119,6 @@ void input_init(void)
     tio_inter.c_cc[VMIN] = 1;
     tio_inter.c_cc[VTIME] = 0;
 
-    using_history();
     rl_readline_name = "msim";
     rl_attempted_completion_function = msim_completion;
 }
@@ -153,7 +153,14 @@ void interactive_control(void)
 
     while (machine_interactive) {
         input_back();
-        char *cmdline = readline(PROMPT);
+
+        // Print the prompt via printf call because of the BSD's editline and GNU's readline library differences.
+        // When the GNU readline sees EOF on the input it still prints the prompt, but the BSD editline doesn't.
+        // To ensure the prompt is printed in both cases, we print it here and flush the output.
+        printf("%s", PROMPT);
+        fflush(stdout);
+
+        char *cmdline = readline(NULL);
         input_shadow();
 
         if (!cmdline) {


### PR DESCRIPTION
Fixes #75. 

The tests on my macOS machine were failing because the history was being initialized only when the output was a console (my mistake :)).

Another issue is the difference in the behaviour of the BSD's editline and GNU's readline when the readline encounters EOF.
In the GNU's case, the prompt `[msim]` is also written to the output but in the BSD's case it is not. 

The output of the mips32-dnomem-break test ran with GNU's readline:
```
$ ../../../msim </dev/null
read
<msim> Alert: Entering interactive mode because of invalid READ (at 0x008000004, 0x4 inside nomem).
[msim]
<msim> Alert: Quit
```

and the output of the same test ran with BSD's editline:
```
$ ../../../msim </dev/null
read
<msim> Alert: Entering interactive mode because of invalid READ (at 0x008000004, 0x4 inside nomem).

<msim> Alert: Quit
```

I fixed this via printing the prompt separately and calling the `readline` with `NULL` as parameter.

Now all the tests are passing on the macOS too.